### PR TITLE
[chore] 운영 서버 DB Flyway 마이그레이션 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// flyway
+	implementation 'org.flywaydb:flyway-core'
+	implementation "org.flywaydb:flyway-mysql"
 }
 
 // plain jar 생성 X 설정

--- a/src/main/java/com/gdg/z_meet/domain/booth/entity/Club.java
+++ b/src/main/java/com/gdg/z_meet/domain/booth/entity/Club.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "Club")
 public class Club extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/booth/entity/Item.java
+++ b/src/main/java/com/gdg/z_meet/domain/booth/entity/Item.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "Item")
 public class Item extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/entity/ChatRoom.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "ChatRoom")
 public class ChatRoom extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/chat/entity/JoinChat.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/entity/JoinChat.java
@@ -10,7 +10,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "JoinChat")
 public class JoinChat extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/chat/entity/Message.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/entity/Message.java
@@ -10,7 +10,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "Message")
 public class Message extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Hi.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Hi.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "Hi")
 public class Hi extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
@@ -11,7 +11,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "Team")
 public class Team extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/UserTeam.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/UserTeam.java
@@ -10,7 +10,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "UserTeam")
 public class UserTeam extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/order/entity/Orders.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/entity/Orders.java
@@ -10,7 +10,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "Orders")
 public class Orders extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/order/entity/TossPayments.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/entity/TossPayments.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "TossPayments")
 public class TossPayments extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/RefreshToken.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "RefreshToken")
 public class RefreshToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/Terms.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/Terms.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "Terms")
 public class Terms extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "User")
 public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -13,7 +13,6 @@ import static com.gdg.z_meet.domain.user.entity.enums.Level.LIGHT;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "UserProfile")
 public class UserProfile {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserTerms.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserTerms.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "UserTerms")
 public class UserTerms extends BaseEntity {
 
     @Id

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    activate:
+      on-profile: prod
   server:
     port: 8081
   datasource:
@@ -9,14 +12,17 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate      # prod 환경에서는 스키마 자동 변경을 막아야
-#      naming:
-#        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-        globally_quoted_identifiers: true
-        globally_quoted_identifiers_skip_column_definitions: true
     show_sql: false        # prod 환경에서는 SQL 출력 비활성화
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    table: _flyway_schema_history
+    baseline-on-migrate: true
+    baseline-version: 1        # 베이스라인으로 간주할 버전(V1)
+    # 추후 baseline-on-migrate: false
   data:
     redis:
       host: redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
     show_sql: true
+  flyway:
+    enabled: false     # dev 환경에서는 flyway 사용 x
   data:
     redis:
       host: localhost

--- a/src/main/resources/db/migration/V1__Initial_Set.sql
+++ b/src/main/resources/db/migration/V1__Initial_Set.sql
@@ -1,0 +1,230 @@
+create table chat_room
+(
+    chat_room_id bigint auto_increment
+        primary key,
+    created_at   datetime(6)  null,
+    updated_at   datetime(6)  null,
+    name         varchar(255) not null
+);
+
+create table club
+(
+    club_id    bigint auto_increment
+        primary key,
+    created_at datetime(6)                               null,
+    updated_at datetime(6)                               null,
+    account    varchar(255)                              null,
+    category   enum ('DATE', 'EVENT', 'FOOD', 'GOODS')   not null,
+    info       varchar(255)                              not null,
+    name       varchar(255)                              not null,
+    place      enum ('A', 'K', 'N', 'S_LEFT', 'S_RIGHT') not null,
+    rep        varchar(255)                              not null,
+    time       varchar(255)                              not null
+);
+
+create table item
+(
+    item_id    bigint auto_increment
+        primary key,
+    created_at datetime(6)  null,
+    updated_at datetime(6)  null,
+    content    varchar(255) not null,
+    name       varchar(255) not null,
+    club_id    bigint       null,
+    constraint FK7jci41cytknpgdb9orcak68tn
+        foreign key (club_id) references club (club_id)
+);
+
+create table notification
+(
+    notification_id bigint auto_increment
+        primary key,
+    created_at      datetime(6) null,
+    updated_at      datetime(6) null
+);
+
+create table refresh_token
+(
+    refresh_token_id bigint auto_increment
+        primary key,
+    key_id           varchar(255) null,
+    refresh_token    varchar(255) null
+);
+
+create table team
+(
+    team_id    bigint auto_increment
+        primary key,
+    created_at datetime(6)                           null,
+    updated_at datetime(6)                           null,
+    gender     enum ('FEMALE', 'MALE')               not null,
+    hi         int                                   not null,
+    name       varchar(7)                            not null,
+    team_type  enum ('THREE_TO_THREE', 'TWO_TO_TWO') not null
+);
+
+create table hi
+(
+    hi_id      bigint auto_increment
+        primary key,
+    created_at datetime(6) null,
+    updated_at datetime(6) null,
+    from_id    bigint      null,
+    to_id      bigint      null,
+    constraint FK93t6nv2nrncgegqvf8nof28mh
+        foreign key (to_id) references team (team_id),
+    constraint FKg8a8236bmo2tpk3fmdang296k
+        foreign key (from_id) references team (team_id)
+);
+
+create table terms
+(
+    terms_id   bigint auto_increment
+        primary key,
+    created_at datetime(6)  null,
+    updated_at datetime(6)  null,
+    content    varchar(255) not null,
+    optional   bit          not null,
+    title      varchar(255) not null
+);
+
+create table user
+(
+    user_id        bigint auto_increment
+        primary key,
+    name           varchar(255) not null,
+    password       varchar(255) not null,
+    student_number varchar(255) not null,
+    constraint UKgj2fy3dcix7ph7k8684gka40c
+        unique (name),
+    constraint UKkiqfjabx9puw3p1eg7kily8kg
+        unique (password),
+    constraint UKqul7p1hvudixi2dmpg80b66h7
+        unique (student_number)
+);
+
+create table join_chat
+(
+    join_chat_id bigint auto_increment
+        primary key,
+    created_at   datetime(6) null,
+    updated_at   datetime(6) null,
+    chat_room_id bigint      null,
+    user_id      bigint      null,
+    constraint FK62dyjbyaa4b5fkvf2newgn1b9
+        foreign key (user_id) references user (user_id),
+    constraint FKb2gkn8xo300ca9dmavoffmgam
+        foreign key (chat_room_id) references chat_room (chat_room_id)
+);
+
+create table message
+(
+    message_id   bigint auto_increment
+        primary key,
+    created_at   datetime(6)  null,
+    updated_at   datetime(6)  null,
+    content      varchar(255) not null,
+    is_read      bit          null,
+    chat_room_id bigint       null,
+    user_id      bigint       null,
+    constraint FK5i8ac68n051032d9ga7gg6i85
+        foreign key (chat_room_id) references chat_room (chat_room_id),
+    constraint FKb3y6etti1cfougkdr0qiiemgv
+        foreign key (user_id) references user (user_id)
+);
+
+create table orders
+(
+    order_id         varchar(255) not null
+        primary key,
+    created_at       datetime(6)  null,
+    updated_at       datetime(6)  null,
+    toss_payments_id varchar(255) null,
+    user_id          bigint       null,
+    constraint UK4logqexg51buromq1npga66so
+        unique (toss_payments_id),
+    constraint FKel9kyl84ego2otj2accfd8mr7
+        foreign key (user_id) references user (user_id)
+);
+
+create table toss_payments
+(
+    toss_payments_id    varchar(255)                                                                                                       not null
+        primary key,
+    created_at          datetime(6)                                                                                                        null,
+    updated_at          datetime(6)                                                                                                        null,
+    approved_at         datetime(6)                                                                                                        null,
+    requested_at        datetime(6)                                                                                                        not null,
+    toss_order_id       varchar(255)                                                                                                       not null,
+    toss_payment_key    varchar(255)                                                                                                       not null,
+    toss_payment_method enum ('CARD', 'EASY_PAYMENT')                                                                                      not null,
+    toss_payment_status enum ('ABORTED', 'CANCELED', 'DONE', 'EXPIRED', 'IN_PROGRESS', 'PARTIAL_CANCELED', 'READY', 'WAITING_FOR_DEPOSIT') not null,
+    total_amount        bigint                                                                                                             not null,
+    orders_id           varchar(255)                                                                                                       not null,
+    constraint UK45lmwc8jxm3taxnv6hhnulk6a
+        unique (toss_payment_key),
+    constraint UKsp79frhmfnbkrbleuwriwtvg1
+        unique (orders_id),
+    constraint FKnjurpc78kvqix69kx89jsqjow
+        foreign key (orders_id) references orders (order_id)
+);
+
+alter table orders
+    add constraint FKmxrhje0pnraft89bdpvi1dbki
+        foreign key (toss_payments_id) references toss_payments (toss_payments_id);
+
+create table user_profile
+(
+    user_profile_id bigint auto_increment
+        primary key,
+    age             int                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    not null,
+    delete_team     int                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    not null,
+    emoji           enum ('GEM', 'HEART_ON_FIRE')                                                                                                                                                                                                                                                                                                                                                                                                                                                                          not null,
+    gender          enum ('FEMALE', 'MALE')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                not null,
+    grade           enum ('FIRST', 'FOURTH', 'SECOND', 'THIRD')                                                                                                                                                                                                                                                                                                                                                                                                                                                            not null,
+    ideal_age       enum ('NO_MATTER', 'OLDER', 'SAME', 'YOUNGER')                                                                                                                                                                                                                                                                                                                                                                                                                                                         not null,
+    ideal_type      enum ('BEAR', 'CAT', 'DINOSAUR', 'DOG', 'FOX', 'HAMSTER', 'RABBIT', 'WOLF')                                                                                                                                                                                                                                                                                                                                                                                                                            not null,
+    level           tinyint                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                not null,
+    major           enum ('ACCOUNTING', 'AI', 'BIOTECH', 'BMCE', 'BMSW', 'BUSINESS', 'CHEMISTRY', 'CHILDREN', 'CHINESE', 'CLOTHING', 'CSIE', 'DA', 'DESIGN', 'ECONOMICS', 'ENGLISH', 'ENVI', 'FOOD_NUTRITION', 'FRENCH', 'GBS', 'ICE', 'INTERNATIONAL_STUDIES', 'JAPANESE', 'KOREAN', 'KOREANHISTORY', 'LAW', 'MATH', 'MEDICAL_BIOLOGY', 'MEDICINE', 'MTC', 'MUSIC', 'NURSING', 'PHARMACY', 'PHILOSOPHY', 'PHYSICS', 'PSYCHOLOGY', 'PUBLIC_ADMINISTRATION', 'SOCIALWELFARE', 'SOCIOLOGY', 'SPECIAL_EDUCATION', 'THEOLOGY') not null,
+    mbti            enum ('ENFJ', 'ENFP', 'ENTJ', 'ENTP', 'ESFJ', 'ESFP', 'ESTJ', 'ESTP', 'INFJ', 'INFP', 'INTJ', 'INTP', 'ISFJ', 'ISFP', 'ISTJ', 'ISTP')                                                                                                                                                                                                                                                                                                                                                                  not null,
+    music           enum ('BALLOD', 'BAND', 'CLASSICAL', 'HIPHOP', 'JPOP', 'KPOP', 'POP', 'ZAZZ')                                                                                                                                                                                                                                                                                                                                                                                                                          not null,
+    nickname        varchar(255)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           not null,
+    style           enum ('CASUAL', 'CUTIE', 'FORMAL', 'HEAP', 'NEAT', 'SPORTY', 'STREET', 'VINTAGE')                                                                                                                                                                                                                                                                                                                                                                                                                      not null,
+    user_id         bigint                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 not null,
+    constraint UKebc21hy5j7scdvcjt0jy6xxrv
+        unique (user_id),
+    constraint UKm9ga0crhcge7onj1gx9a5lnjy
+        unique (nickname),
+    constraint FK6kwj5lk78pnhwor4pgosvb51r
+        foreign key (user_id) references user (user_id)
+);
+
+create table user_team
+(
+    user_team_id bigint auto_increment
+        primary key,
+    created_at   datetime(6) null,
+    updated_at   datetime(6) null,
+    team_id      bigint      null,
+    user_id      bigint      null,
+    constraint FK6d6agqknw564xtsa91d3259wu
+        foreign key (team_id) references team (team_id),
+    constraint FKd6um0sk8hyytfq7oalt5a4nph
+        foreign key (user_id) references user (user_id)
+);
+
+create table user_terms
+(
+    user_terms_id bigint auto_increment
+        primary key,
+    created_at    datetime(6) null,
+    updated_at    datetime(6) null,
+    agree         bit         not null,
+    terms_id      bigint      null,
+    user_id       bigint      null,
+    constraint FKi12icigeb1prcyhv7cdfyyv4e
+        foreign key (user_id) references user (user_id),
+    constraint FKsv90iyco7g8yl9kbml0m5pjhl
+        foreign key (terms_id) references terms (terms_id)
+);
+


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #21 

## ⚡️ 작업동기

배포 환경에서의 DB 관리

## 🔑 주요 변경사항

JPA Hibernate 의 ddl-auto 는 validate 로 검증 용도로만 사용하고,
migration 라이브러리인 Flyway를 사용해서 운영 DB를 관리할 예정입니다.

8080 포트로 RDS 접근을 직접 못하게 막아놨기에, 머지 후 EC2에서 테스트 하겠습니다. 



+) hibernate가 자동으로 생성하는거 사용하도록 @Table 어노테이션 전부 제거하였습니다.

