### PR TITLE
[feat] 미팅 팀 소개 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -3,7 +3,6 @@ package com.gdg.z_meet.domain.meeting.controller;
 import com.gdg.z_meet.domain.meeting.converter.MeetingConverter;
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
-import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.global.response.Response;
@@ -24,9 +23,9 @@ public class MeetingController {
 
     @Operation(summary = "팀 상세 조회")
     @GetMapping("/detail/{teamId}")
-    public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId) {
+    public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId, @RequestParam Long userId) {
 
-        Team team = meetingQueryService.getTeam(teamId);
+        Team team = meetingQueryService.getTeam(userId, teamId);
         List<User> users = meetingQueryService.getUserTeam(teamId);
         return Response.ok(MeetingConverter.toGetTeamDTO(team, users));
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -5,6 +5,7 @@ import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
 import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.global.common.AuthenticatedUserUtils;
 import com.gdg.z_meet.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +24,9 @@ public class MeetingController {
 
     @Operation(summary = "팀 상세 조회")
     @GetMapping("/detail/{teamId}")
-    public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId, @RequestParam Long userId) {
+    public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId) {
 
+        Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         Team team = meetingQueryService.getTeam(userId, teamId);
         List<User> users = meetingQueryService.getUserTeam(teamId);
         return Response.ok(MeetingConverter.toGetTeamDTO(team, users));

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -3,12 +3,16 @@ package com.gdg.z_meet.domain.meeting.controller;
 import com.gdg.z_meet.domain.meeting.converter.MeetingConverter;
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
+import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +27,7 @@ public class MeetingController {
     public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId) {
 
         Team team = meetingQueryService.getTeam(teamId);
-        return Response.ok(MeetingConverter.toGetTeamDTO(team));
+        List<User> users = meetingQueryService.getUserTeam(teamId);
+        return Response.ok(MeetingConverter.toGetTeamDTO(team, users));
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -9,6 +9,7 @@ import com.gdg.z_meet.global.common.AuthenticatedUserUtils;
 import com.gdg.z_meet.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,7 @@ public class MeetingController {
 
     @Operation(summary = "팀 소개 상세 조회", description = "본인 팀은 조회가 불가능합니다.")
     @GetMapping("/{teamId}")
-    public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId) {
+    public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable @Positive(message = "팀 ID는 양수여야 합니다.") Long teamId) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         Team team = meetingQueryService.getTeam(userId, teamId);

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -30,8 +30,8 @@ public class MeetingController {
     public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable @Positive(message = "팀 ID는 양수여야 합니다.") Long teamId) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
-        Team team = meetingQueryService.getTeam(userId, teamId);
-        List<User> users = meetingQueryService.getUserTeam(teamId);
-        return Response.ok(MeetingConverter.toGetTeamDTO(team, users));
+        MeetingResponseDTO.GetTeamDTO response = meetingQueryService.getTeam(userId, teamId);
+
+        return Response.ok(response);
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -1,0 +1,28 @@
+package com.gdg.z_meet.domain.meeting.controller;
+
+import com.gdg.z_meet.domain.meeting.converter.MeetingConverter;
+import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
+import com.gdg.z_meet.global.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/meeting")
+@Validated
+public class MeetingController {
+
+    private final MeetingQueryService meetingQueryService;
+
+    @Operation(summary = "팀 상세 조회")
+    @GetMapping("/detail/{teamId}")
+    public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId) {
+
+        Team team = meetingQueryService.getTeam(teamId);
+        return Response.ok(MeetingConverter.toGetTeamDTO(team));
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -8,6 +8,7 @@ import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.global.common.AuthenticatedUserUtils;
 import com.gdg.z_meet.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -17,13 +18,14 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/meeting")
+@Tag(name = "Meeting")
 @Validated
 public class MeetingController {
 
     private final MeetingQueryService meetingQueryService;
 
-    @Operation(summary = "팀 상세 조회")
-    @GetMapping("/detail/{teamId}")
+    @Operation(summary = "팀 소개 상세 조회", description = "본인 팀은 조회가 불가능합니다.")
+    @GetMapping("/{teamId}")
     public Response<MeetingResponseDTO.GetTeamDTO> getTeam(@PathVariable Long teamId) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -2,7 +2,6 @@ package com.gdg.z_meet.domain.meeting.converter;
 
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
-import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.user.entity.User;
 
 import java.util.List;

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -1,0 +1,15 @@
+package com.gdg.z_meet.domain.meeting.converter;
+
+import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
+import com.gdg.z_meet.domain.meeting.entity.Team;
+
+public class MeetingConverter {
+
+    public static MeetingResponseDTO.GetTeamDTO toGetTeamDTO(Team team){
+
+        return MeetingResponseDTO.GetTeamDTO.builder()
+                .teamId(team.getId())
+                .name(team.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -2,14 +2,36 @@ package com.gdg.z_meet.domain.meeting.converter;
 
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.UserTeam;
+import com.gdg.z_meet.domain.user.entity.User;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MeetingConverter {
 
-    public static MeetingResponseDTO.GetTeamDTO toGetTeamDTO(Team team){
+    public static MeetingResponseDTO.GetTeamDTO toGetTeamDTO(Team team, List<User> users){
+
+        List<MeetingResponseDTO.GetTeamUserDTO> teamUserDTOS = users.stream()
+                .map(user -> MeetingResponseDTO.GetTeamUserDTO.builder()
+                        .userId(user.getId())
+                        .emoji(String.valueOf(user.getUserProfile().getEmoji()))
+                        .nickname(user.getUserProfile().getNickname())
+                        .age(user.getUserProfile().getAge())
+                        .studentNumber(user.getStudentNumber())
+                        .major(String.valueOf(user.getUserProfile().getMajor()))
+                        .music(String.valueOf(user.getUserProfile().getMusic()))
+                        .mbti(String.valueOf(user.getUserProfile().getMbti()))
+                        .style(String.valueOf(user.getUserProfile().getStyle()))
+                        .idealType(String.valueOf(user.getUserProfile().getIdealType()))
+                        .idealAge(String.valueOf(user.getUserProfile().getIdealAge()))
+                        .build())
+                .collect(Collectors.toList());
 
         return MeetingResponseDTO.GetTeamDTO.builder()
                 .teamId(team.getId())
                 .name(team.getName())
+                .userList(teamUserDTOS)
                 .build();
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -18,7 +18,7 @@ public class MeetingConverter {
                         .emoji(String.valueOf(user.getUserProfile().getEmoji()))
                         .nickname(user.getUserProfile().getNickname())
                         .age(user.getUserProfile().getAge())
-                        .studentNumber(user.getStudentNumber())
+                        .studentNumber(user.getStudentNumber().substring(2, 4))
                         .major(String.valueOf(user.getUserProfile().getMajor()))
                         .music(String.valueOf(user.getUserProfile().getMusic()))
                         .mbti(String.valueOf(user.getUserProfile().getMbti()))

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
@@ -1,0 +1,10 @@
+package com.gdg.z_meet.domain.meeting.dto;
+
+import com.gdg.z_meet.global.validation.annotation.ValidEnum;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class MeetingRequestDTO {
+
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -1,0 +1,20 @@
+package com.gdg.z_meet.domain.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class MeetingResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetTeamDTO {
+        Long teamId;
+        String name;
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -13,8 +13,29 @@ public class MeetingResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class GetTeamUserDTO {
+        Long userId;
+        String emoji;
+        String nickname;
+        Integer age;
+        String studentNumber;
+        String major;
+        String music;
+
+        // 지밋 플러스
+        String mbti;
+        String style;
+        String idealType;
+        String idealAge;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class GetTeamDTO {
         Long teamId;
         String name;
+        List<GetTeamUserDTO> userList;
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
@@ -34,4 +34,9 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private Integer hi = 2;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Verification verification = Verification.NONE;
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Verification.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Verification.java
@@ -1,0 +1,5 @@
+package com.gdg.z_meet.domain.meeting.entity;
+
+public enum Verification {
+    NONE, IN_PROGRESS, COMPLETE
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/MeetingRepository.java
@@ -1,0 +1,7 @@
+package com.gdg.z_meet.domain.meeting.repository;
+
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -3,5 +3,5 @@ package com.gdg.z_meet.domain.meeting.repository;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MeetingRepository extends JpaRepository<Team, Long> {
+public interface TeamRepository extends JpaRepository<Team, Long> {
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -1,0 +1,15 @@
+package com.gdg.z_meet.domain.meeting.repository;
+
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.UserTeam;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
+
+    List<UserTeam> findByTeamId(Long teamId);
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -4,9 +4,11 @@ import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
+    boolean existsByUserIdAndTeamId(Long userId, Long teamId);
     List<UserTeam> findByTeamId(Long teamId);
     Integer countByTeamId(Long id);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -1,15 +1,12 @@
 package com.gdg.z_meet.domain.meeting.repository;
 
-import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     List<UserTeam> findByTeamId(Long teamId);
+    Integer countByTeamId(Long id);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -1,8 +1,12 @@
 package com.gdg.z_meet.domain.meeting.service;
 
 import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.user.entity.User;
+
+import java.util.List;
 
 public interface MeetingQueryService {
 
     public Team getTeam(Long teamId);
+    public List<User> getUserTeam(Long teamId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -1,12 +1,8 @@
 package com.gdg.z_meet.domain.meeting.service;
 
-import com.gdg.z_meet.domain.meeting.entity.Team;
-import com.gdg.z_meet.domain.user.entity.User;
-
-import java.util.List;
+import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 
 public interface MeetingQueryService {
 
-    Team getTeam(Long userId, Long teamId);
-    List<User> getUserTeam(Long teamId);
+    MeetingResponseDTO.GetTeamDTO getTeam(Long userId, Long teamId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface MeetingQueryService {
 
-    public Team getTeam(Long teamId);
+    public Team getTeam(Long userId, Long teamId);
     public List<User> getUserTeam(Long teamId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -1,0 +1,8 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.entity.Team;
+
+public interface MeetingQueryService {
+
+    public Team getTeam(Long teamId);
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface MeetingQueryService {
 
-    public Team getTeam(Long userId, Long teamId);
-    public List<User> getUserTeam(Long teamId);
+    Team getTeam(Long userId, Long teamId);
+    List<User> getUserTeam(Long teamId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.repository.MeetingRepository;
+import com.gdg.z_meet.global.exception.BusinessException;
+import com.gdg.z_meet.global.response.Code;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingQueryServiceImpl implements MeetingQueryService {
+
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    public Team getTeam(Long teamId) {
+        return meetingRepository.findById(teamId).orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -35,6 +35,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<User> getUserTeam(Long teamId) {
 
         List<UserTeam> userTeams = userTeamRepository.findByTeamId(teamId);

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -1,20 +1,38 @@
 package com.gdg.z_meet.domain.meeting.service;
 
 import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.repository.MeetingRepository;
+import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
+import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.global.exception.BusinessException;
 import com.gdg.z_meet.global.response.Code;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MeetingQueryServiceImpl implements MeetingQueryService {
 
     private final MeetingRepository meetingRepository;
+    private final UserTeamRepository userTeamRepository;
 
     @Override
     public Team getTeam(Long teamId) {
+
         return meetingRepository.findById(teamId).orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
+    }
+
+    @Override
+    public List<User> getUserTeam(Long teamId) {
+        List<UserTeam> userTeams = userTeamRepository.findByTeamId(teamId);
+        return userTeams.stream()
+                .map(UserTeam::getUser)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -24,8 +24,11 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public Team getTeam(Long teamId) {
+    public Team getTeam(Long userId, Long teamId) {
 
+        if (userTeamRepository.existsByUserIdAndTeamId(userId, teamId)) {
+            throw new BusinessException(Code.INVALID_MY_TEAM_ACCESS);
+        }
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
         validateTeamType(teamId, team.getTeamType());
         return team;
@@ -33,6 +36,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
 
     @Override
     public List<User> getUserTeam(Long teamId) {
+
         List<UserTeam> userTeams = userTeamRepository.findByTeamId(teamId);
         return userTeams.stream()
                 .map(UserTeam::getUser)

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.gdg.z_meet.domain.meeting.service;
 
+import com.gdg.z_meet.domain.meeting.converter.MeetingConverter;
+import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.TeamType;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
@@ -24,24 +26,20 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public Team getTeam(Long userId, Long teamId) {
+    public MeetingResponseDTO.GetTeamDTO getTeam(Long userId, Long teamId) {
 
         if (userTeamRepository.existsByUserIdAndTeamId(userId, teamId)) {
             throw new BusinessException(Code.INVALID_MY_TEAM_ACCESS);
         }
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
         validateTeamType(teamId, team.getTeamType());
-        return team;
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<User> getUserTeam(Long teamId) {
 
         List<UserTeam> userTeams = userTeamRepository.findByTeamId(teamId);
-        return userTeams.stream()
+        List<User> users = userTeams.stream()
                 .map(UserTeam::getUser)
                 .collect(Collectors.toList());
+
+        return MeetingConverter.toGetTeamDTO(team, users);
     }
 
     private void validateTeamType(Long teamId, TeamType teamType) {

--- a/src/main/java/com/gdg/z_meet/global/common/AuthenticatedUserUtils.java
+++ b/src/main/java/com/gdg/z_meet/global/common/AuthenticatedUserUtils.java
@@ -1,0 +1,37 @@
+package com.gdg.z_meet.global.common;
+
+import com.gdg.z_meet.domain.user.entity.User;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticatedUserUtils {
+
+    private AuthenticatedUserUtils() {}
+
+    public static String getAuthenticatedStudentNumber(){
+
+        // 현재 인증된 사용자 정보 가져오기
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof User user) {    // Principal 의 객체 타입 확인
+            return user.getStudentNumber();
+        } else if (principal != null) {
+            return principal.toString();
+        } else {
+            throw new IllegalArgumentException("현재 인증된 사용자를 찾을 수 없습니다.");
+        }
+    }
+
+    public static Long getAuthenticatedUserId(){
+
+        // 현재 인증된 사용자 정보 가져오기
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof User user) {    // Principal 의 객체 타입 확인
+            return user.getId();
+        } else {
+            throw new IllegalArgumentException("현재 인증된 사용자를 찾을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/gdg/z_meet/global/config/SwaggerConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.gdg.z_meet.global.config;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,9 +13,30 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+
+        String accessTokenSchemeName = "accessToken";
+        String refreshTokenSchemeName = "refreshToken";
+
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(accessTokenSchemeName);
+
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(accessTokenSchemeName, new SecurityScheme()
+                        .name("accessToken")
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .scheme("bearer")
+                        .bearerFormat("JWT"))
+                .addSecuritySchemes(refreshTokenSchemeName, new SecurityScheme()
+                        .name("refreshToken")
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
         return new OpenAPI()
-                .components(new Components())
-                .info(apiInfo());
+                .components(components)
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement);
     }
 
     private Info apiInfo() {

--- a/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.gdg.z_meet.global.exception;
 import com.gdg.z_meet.global.response.Code;
 import com.gdg.z_meet.global.response.ReasonDTO;
 import com.gdg.z_meet.global.response.Response;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -45,6 +46,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getFieldErrors()
                 .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
@@ -55,8 +57,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     }
 
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException ex) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<Void>> handleAllException(Exception ex) {
+
         log.error("Unhandled exception occurred", ex);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -33,6 +33,8 @@ public enum Code implements BaseCode {
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING4001", "팀을 찾을 수 없습니다."),
     TEAM_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING4002", "팀원을 찾을 수 없습니다."),
     TEAM_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4003", "팀원 수가 일치하지 않습니다."),
+    INVALID_MY_TEAM_ACCESS(HttpStatus.BAD_REQUEST, "MEETING4004", "본인 팀은 조회할 수 없습니다."),
+    INVALID_OTHER_TEAM_ACCESS(HttpStatus.BAD_REQUEST, "MEETING4005", "다른 팀은 조회할 수 없습니다."),
     ;
 
 //    NOT_ACADEMY_EMAIL("EEM-001", "Email is not a university email."),

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -28,7 +28,9 @@ public enum Code implements BaseCode {
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "PAY-002", "Invalid payment amount."),
 
     CLUB_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "BOOTH4001", "동아리가 이미 존재합니다."),
-    CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOOTH4002", "동아리를 찾을 수 없습니다."),
+    CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOTH4002", "동아리를 찾을 수 없습니다."),
+
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING4001", "팀을 찾을 수 없습니다."),
     ;
 
 //    NOT_ACADEMY_EMAIL("EEM-001", "Email is not a university email."),

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -32,6 +32,7 @@ public enum Code implements BaseCode {
 
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING4001", "팀을 찾을 수 없습니다."),
     TEAM_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING4002", "팀원을 찾을 수 없습니다."),
+    TEAM_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4003", "팀원 수가 일치하지 않습니다."),
     ;
 
 //    NOT_ACADEMY_EMAIL("EEM-001", "Email is not a university email."),

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -31,6 +31,7 @@ public enum Code implements BaseCode {
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOTH4002", "동아리를 찾을 수 없습니다."),
 
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING4001", "팀을 찾을 수 없습니다."),
+    TEAM_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING4002", "팀원을 찾을 수 없습니다."),
     ;
 
 //    NOT_ACADEMY_EMAIL("EEM-001", "Email is not a university email."),


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#19_team-gallery

## ⚡️ 작업동기

- 2대2, 3대3 미팅 팀 소개(상세조회) 구현

## 🔑 주요 변경사항

- GET /meeting/{teamId} API 개발
- 지밋 플러스 검증은 추후 개발할 예정입니다.
- 본인이 포함된 팀은 조회가 불가능합니다. GET /meeting/myTeam 으로만 조회하도록 구현할 예정입니다.
- AuthenticatedUserUtils로 로그인 한 유저의 정보를 검증하는 코드를 작성하였습니다. 이 부분 확인하고 피드백 주시면 감사하겠습니다 :)

## 💡 관련 이슈

- #19 

![localhost_8080_swagger-ui_index html (9)](https://github.com/user-attachments/assets/10138504-8074-40fb-b668-a74e8227a596)
![localhost_8080_swagger-ui_index html (10)](https://github.com/user-attachments/assets/5f9f248d-f95f-479e-b176-1ef852bece4b)
