### PR TITLE
[feat] 우리팀 소개 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -40,4 +40,14 @@ public class MeetingController {
 
         return Response.ok(response);
     }
+
+    @Operation(summary = "우리 팀 상세 조회")
+    @GetMapping("/myTeam")
+    public Response<MeetingResponseDTO.GetTeamDTO> getMyTeam(@RequestParam TeamType teamType) {
+
+        Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
+        MeetingResponseDTO.GetTeamDTO response = meetingQueryService.getMyTeam(userId, teamType);
+
+        return Response.ok(response);
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -41,8 +41,18 @@ public class MeetingController {
         return Response.ok(response);
     }
 
-    @Operation(summary = "우리 팀 상세 조회")
+    @Operation(summary = "우리 팀 조회")
     @GetMapping("/myTeam")
+    public Response<MeetingResponseDTO.GetMyTeamDTO> getPreMyTeam(@RequestParam TeamType teamType) {
+
+        Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
+        MeetingResponseDTO.GetMyTeamDTO response = meetingQueryService.getPreMyTeam(userId, teamType);
+
+        return Response.ok(response);
+    }
+
+    @Operation(summary = "우리 팀 상세 조회")
+    @GetMapping("/myTeam/detail")
     public Response<MeetingResponseDTO.GetTeamDTO> getMyTeam(@RequestParam TeamType teamType) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -61,4 +61,14 @@ public class MeetingConverter {
                 .userList(teamUserDTOS)
                 .build();
     }
+
+    public static MeetingResponseDTO.GetMyTeamDTO toGetMyTeamDTO(Team team, List<String> emojiList){
+
+        return MeetingResponseDTO.GetMyTeamDTO.builder()
+                .teamId(team.getId())
+                .emoji(emojiList)
+                .name(team.getName())
+                .verification(team.getVerification() == COMPLETE ? 1 : 0)
+                .build();
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -56,6 +56,7 @@ public class MeetingConverter {
         return MeetingResponseDTO.GetTeamDTO.builder()
                 .teamId(team.getId())
                 .name(team.getName())
+                .verification(team.getVerification() == COMPLETE ? 1 : 0)
                 .gender(String.valueOf(team.getGender()))
                 .userList(teamUserDTOS)
                 .build();

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -62,4 +62,15 @@ public class MeetingResponseDTO {
         String gender;
         List<GetTeamUserDTO> userList;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetMyTeamDTO {
+        Long teamId;
+        List<String> emoji;
+        String name;
+        Integer verification;
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -58,6 +58,7 @@ public class MeetingResponseDTO {
     public static class GetTeamDTO {
         Long teamId;
         String name;
+        Integer verification;
         String gender;
         List<GetTeamUserDTO> userList;
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -8,10 +8,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t WHERE t.id NOT IN (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId) " +
             "AND t.gender != :gender AND t.teamType = :teamType")
     List<Team> findAllByTeamType(Long userId, Gender gender, TeamType teamType, Pageable pageable);
+
+    @Query("SELECT t FROM Team t WHERE t.id IN (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId) " +
+            "AND t.teamType = :teamType")
+    Optional<Team> findByTeamType(Long userId, TeamType teamType);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -7,4 +7,5 @@ public interface MeetingQueryService {
 
     MeetingResponseDTO.GetTeamGalleryDTO getTeamGallery(Long userId, TeamType teamType, Integer page);
     MeetingResponseDTO.GetTeamDTO getTeam(Long userId, Long teamId);
+    MeetingResponseDTO.GetTeamDTO getMyTeam(Long userId, TeamType teamType);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -7,5 +7,6 @@ public interface MeetingQueryService {
 
     MeetingResponseDTO.GetTeamGalleryDTO getTeamGallery(Long userId, TeamType teamType, Integer page);
     MeetingResponseDTO.GetTeamDTO getTeam(Long userId, Long teamId);
+    MeetingResponseDTO.GetMyTeamDTO getPreMyTeam(Long userId, TeamType teamType);
     MeetingResponseDTO.GetTeamDTO getMyTeam(Long userId, TeamType teamType);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -94,6 +94,22 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
     }
 
     @Override
+    public MeetingResponseDTO.GetMyTeamDTO getPreMyTeam(Long userId, TeamType teamType) {
+
+        Team team = teamRepository.findByTeamType(userId, teamType)
+                .orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
+
+        validateTeamType(team.getId(), teamType);
+
+        List<UserTeam> userTeams = userTeamRepository.findByTeamId(team.getId());
+        List<String> emojiList = userTeams.stream()
+                            .map(userTeam -> userTeam.getUser().getUserProfile().getEmoji())
+                            .collect(Collectors.toList());
+
+        return MeetingConverter.toGetMyTeamDTO(team, emojiList);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public MeetingResponseDTO.GetTeamDTO getMyTeam(Long userId, TeamType teamType) {
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -93,6 +93,23 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
         return MeetingConverter.toGetTeamDTO(team, users);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public MeetingResponseDTO.GetTeamDTO getMyTeam(Long userId, TeamType teamType) {
+
+        Team team = teamRepository.findByTeamType(userId, teamType)
+                .orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
+
+        validateTeamType(team.getId(), teamType);
+
+        List<UserTeam> userTeams = userTeamRepository.findByTeamId(team.getId());
+        List<User> users = userTeams.stream()
+                .map(UserTeam::getUser)
+                .collect(Collectors.toList());
+
+        return MeetingConverter.toGetTeamDTO(team, users);
+    }
+
     private void validateTeamType(Long teamId, TeamType teamType) {
 
         Long userCount = userTeamRepository.countByTeamId(teamId);

--- a/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
@@ -60,6 +60,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
+    }
+
     @ExceptionHandler(IncorrectResultSizeDataAccessException.class)
     public ResponseEntity<Object> handleIncorrectResultSizeException(IncorrectResultSizeDataAccessException ex) {
 

--- a/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.gdg.z_meet.global.response.Code;
 import com.gdg.z_meet.global.response.Response;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -53,6 +54,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException ex) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
+    }
+
+    @ExceptionHandler(IncorrectResultSizeDataAccessException.class)
+    public ResponseEntity<Object> handleIncorrectResultSizeException(IncorrectResultSizeDataAccessException ex) {
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#45_my-team

## ⚡️ 작업동기

- 2대2, 3대3 미팅 우리팀 소개(상세 조회) 로직 구현

## 🔑 주요 변경사항

- GET /meeting/myTeam API 개발
- GET /meeting/myTeam/detail API 개발
- 팀 타입마다 유저가 속한 팀이 2개 이상일 경우 에러가 발생합니다!
팀 생성 로직에서, 팀 타입당 한 팀씩만 생성할 수 있도록 구현할 예정이라서 별도의 처리 없이 진행하였습니다 :)

## 💡 관련 이슈

- #45 

![스크린샷 2025-02-07 011502](https://github.com/user-attachments/assets/7d4d7665-b750-4691-8628-a09cf2b31bd9)
![스크린샷 2025-02-07 011522](https://github.com/user-attachments/assets/e48bd019-3a83-4804-a5cf-7c846d971c14)
