### PR TITLE
[feat] 팀명 중복확인 기능 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -8,6 +8,7 @@ import com.gdg.z_meet.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -57,6 +58,15 @@ public class MeetingController {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         MeetingResponseDTO.GetTeamDTO response = meetingQueryService.getMyTeam(userId, teamType);
+
+        return Response.ok(response);
+    }
+
+    @Operation(summary = "팀명 중복확인")
+    @GetMapping("/teamName")
+    public Response<MeetingResponseDTO.CheckNameDTO> checkName(@RequestParam @Size(min = 1, max = 7) String name) {
+
+        MeetingResponseDTO.CheckNameDTO response = meetingQueryService.checkName(name);
 
         return Response.ok(response);
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -73,4 +73,12 @@ public class MeetingResponseDTO {
         String name;
         Integer verification;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CheckNameDTO {
+        Integer check;
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -19,4 +19,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     @Query("SELECT t FROM Team t WHERE t.id IN (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId) " +
             "AND t.teamType = :teamType")
     Optional<Team> findByTeamType(Long userId, TeamType teamType);
+
+    Boolean existsByName(String name);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -9,4 +9,5 @@ public interface MeetingQueryService {
     MeetingResponseDTO.GetTeamDTO getTeam(Long userId, Long teamId);
     MeetingResponseDTO.GetMyTeamDTO getPreMyTeam(Long userId, TeamType teamType);
     MeetingResponseDTO.GetTeamDTO getMyTeam(Long userId, TeamType teamType);
+    MeetingResponseDTO.CheckNameDTO checkName(String name);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -126,6 +126,16 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
         return MeetingConverter.toGetTeamDTO(team, users);
     }
 
+    @Override
+    public MeetingResponseDTO.CheckNameDTO checkName(String name) {
+
+        Boolean exist = teamRepository.existsByName(name);
+
+        return MeetingResponseDTO.CheckNameDTO.builder()
+                .check(exist == Boolean.TRUE ? 0 : 1)
+                .build();
+    }
+
     private void validateTeamType(Long teamId, TeamType teamType) {
 
         Long userCount = userTeamRepository.countByTeamId(teamId);


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#49_team-name

## ⚡️ 작업동기

- 팀 생성하기 시, 팀명 중복확인 기능 구현

## 🔑 주요 변경사항

- 팀명 검색 GET /meeting/name API 개발
- 프론트와 협의해서 요청 응답을 Integer(0-중복, 1-중복 아님)로 보내주도록 개발하였습니다.
- 글자수 제한(1~7글자)

## 💡 관련 이슈

- #49 
![스크린샷 2025-02-09 025204](https://github.com/user-attachments/assets/42b86cad-0978-4d8d-b376-662deb14340c)
![스크린샷 2025-02-09 025220](https://github.com/user-attachments/assets/cd18a6a8-11d6-4187-81a3-b7012ce7c549)
