### PR TITLE
[refactor] 팀 전공, 음악 중복처리

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -52,6 +52,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
                     List<UserTeam> userTeams = userTeamRepository.findByTeamId(team.getId());
                     return userTeams.stream()
                             .map(userTeam -> String.valueOf(userTeam.getUser().getUserProfile().getMajor()))
+                            .distinct()
                             .collect(Collectors.toList());
                 }
         ));
@@ -68,6 +69,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
                     List<UserTeam> userTeams = userTeamRepository.findByTeamId(team.getId());
                     return userTeams.stream()
                             .map(userTeam -> String.valueOf(userTeam.getUser().getUserProfile().getMusic()))
+                            .distinct()
                             .collect(Collectors.toList());
                 }
         ));


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #51 

## ⚡️ 작업동기

- 팀 갤러리 조회 시, 전공, 음악 중복처리

## 🔑 주요 변경사항

- GET /meeting 반환 시 distinct 옵션 추가

## 💡 관련 이슈

- #51 

![스크린샷 2025-02-09 203156](https://github.com/user-attachments/assets/206fdaa5-95f0-4700-b0e8-573ef42aeef6)
