### PR TITLE
[feat] 팀 만들기 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -1,7 +1,9 @@
 package com.gdg.z_meet.domain.meeting.controller;
 
+import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.TeamType;
+import com.gdg.z_meet.domain.meeting.service.MeetingCommandService;
 import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
 import com.gdg.z_meet.global.common.AuthenticatedUserUtils;
 import com.gdg.z_meet.global.response.Response;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class MeetingController {
 
     private final MeetingQueryService meetingQueryService;
+    private final MeetingCommandService meetingCommandService;
 
     @Operation(summary = "팀 갤러리 조회", description = "12팀씩 페이징 됩니다.")
     @GetMapping
@@ -60,6 +63,16 @@ public class MeetingController {
         MeetingResponseDTO.GetTeamDTO response = meetingQueryService.getMyTeam(userId, teamType);
 
         return Response.ok(response);
+    }
+
+    @Operation(summary = "팀 만들기")
+    @PostMapping("/myTeam")
+    public Response<Void> creatTeam(@RequestParam TeamType teamType, @RequestBody MeetingRequestDTO.CreateTeamDTO request) {
+
+        Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
+        meetingCommandService.createTeam(userId, teamType, request);
+
+        return Response.ok();
     }
 
     @Operation(summary = "팀명 중복확인")

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -2,6 +2,7 @@ package com.gdg.z_meet.domain.meeting.converter;
 
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.user.entity.User;
 
 import java.util.List;
@@ -69,6 +70,14 @@ public class MeetingConverter {
                 .emoji(emojiList)
                 .name(team.getName())
                 .verification(team.getVerification() == COMPLETE ? 1 : 0)
+                .build();
+    }
+
+    public static void toCreateUserTeam(User user, Team team) {
+
+        UserTeam.builder()
+                .user(user)
+                .team(team)
                 .build();
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -73,7 +73,7 @@ public class MeetingConverter {
                 .build();
     }
 
-    public static void toCreateUserTeam(User user, Team team) {
+    public static void toUserTeam(User user, Team team) {
 
         UserTeam.builder()
                 .user(user)

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
@@ -1,10 +1,22 @@
 package com.gdg.z_meet.domain.meeting.dto;
 
-import com.gdg.z_meet.global.validation.annotation.ValidEnum;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
+
+import java.util.List;
 
 public class MeetingRequestDTO {
 
+    @Getter
+    public static class CreateTeamDTO {
+
+        @NotBlank
+        @Size(min = 1, max = 7)
+        String name;
+
+        @NotNull
+        List<Long> teamMember;
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -6,6 +6,7 @@ import com.gdg.z_meet.domain.user.entity.enums.Gender;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,16 +15,16 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t WHERE t.id NOT IN (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId) " +
             "AND t.gender != :gender AND t.teamType = :teamType")
-    List<Team> findAllByTeamType(Long userId, Gender gender, TeamType teamType, Pageable pageable);
+    List<Team> findAllByTeamType(@Param("userId") Long userId, @Param("gender") Gender gender, @Param("teamType") TeamType teamType, Pageable pageable);
 
     @Query("SELECT t FROM Team t WHERE t.id IN (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId) " +
             "AND t.teamType = :teamType")
-    Optional<Team> findByTeamType(Long userId, TeamType teamType);
+    Optional<Team> findByTeamType(@Param("userId") Long userId,@Param("teamType") TeamType teamType);
 
     Boolean existsByName(String name);
 
-    @Query("SELECT EXISTS (SELECT 1 FROM Team t " +
-            "JOIN UserTeam ut ON ut.team.id = t.id " +
-            "WHERE ut.user.id = :userId AND t.teamType = :teamType)")
-    Boolean existsByTeamType(Long userId, TeamType teamType);
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM Team t " +
+            "JOIN UserTeam ut ON ut.team = t " +
+            "WHERE ut.user.id IN :userIds AND t.teamType = :teamType")
+    Boolean existsAnyMemberByTeamType(@Param("userIds") List<Long> userIds, @Param("teamType") TeamType teamType);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -21,4 +21,9 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByTeamType(Long userId, TeamType teamType);
 
     Boolean existsByName(String name);
+
+    @Query("SELECT EXISTS (SELECT 1 FROM Team t " +
+            "JOIN UserTeam ut ON ut.team.id = t.id " +
+            "WHERE ut.user.id = :userId AND t.teamType = :teamType)")
+    Boolean existsByTeamType(Long userId, TeamType teamType);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     boolean existsByUserIdAndTeamId(Long userId, Long teamId);
-    boolean existsByUserIdAndTeamType(Long userId, TeamType teamType);
     List<UserTeam> findByTeamId(Long teamId);
     List<UserTeam> findByTeamIdIn(List<Long> teamIds);
     Long countByTeamId(Long id);

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -1,5 +1,6 @@
 package com.gdg.z_meet.domain.meeting.repository;
 
+import com.gdg.z_meet.domain.meeting.entity.TeamType;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +10,7 @@ import java.util.Optional;
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     boolean existsByUserIdAndTeamId(Long userId, Long teamId);
+    boolean existsByUserIdAndTeamType(Long userId, TeamType teamType);
     List<UserTeam> findByTeamId(Long teamId);
     List<UserTeam> findByTeamIdIn(List<Long> teamIds);
     Long countByTeamId(Long id);

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandService.java
@@ -1,0 +1,9 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
+import com.gdg.z_meet.domain.meeting.entity.TeamType;
+
+public interface MeetingCommandService {
+
+    void createTeam(Long userId, TeamType teamType, MeetingRequestDTO.CreateTeamDTO request);
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -1,0 +1,54 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.converter.MeetingConverter;
+import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.TeamType;
+import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.enums.Gender;
+import com.gdg.z_meet.domain.user.repository.UserProfileRepository;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import com.gdg.z_meet.global.exception.BusinessException;
+import com.gdg.z_meet.global.response.Code;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingCommandServiceImpl implements MeetingCommandService {
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final TeamRepository teamRepository;
+
+    @Override
+    @Transactional
+    public void createTeam(Long userId, TeamType teamType, MeetingRequestDTO.CreateTeamDTO request) {
+
+        int userCount = request.getTeamMember().size();
+        if (teamType == TeamType.TWO_TO_TWO && userCount != 2) {
+            throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
+        } else if (teamType == TeamType.THREE_TO_THREE && userCount != 3) {
+            throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
+        }
+
+        Gender gender = userProfileRepository.findById(userId).get().getGender();
+        Team newTeam = Team.builder()
+                        .teamType(teamType)
+                        .name(request.getName())
+                        .gender(gender)
+                        .build();
+        teamRepository.save(newTeam);
+
+        for(Long teamMemberId : request.getTeamMember()) {
+
+            User user = userRepository.findById(teamMemberId).get();
+            if (user.getUserProfile().getGender() != gender) {
+                throw new BusinessException(Code.TEAM_GENDER_MISMATCH);
+            }
+            MeetingConverter.toCreateUserTeam(user, newTeam);
+        }
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingCommandServiceImpl implements MeetingCommandService {
 
     private final UserRepository userRepository;
-    private final UserTeamRepository userTeamRepository;
     private final UserProfileRepository userProfileRepository;
     private final TeamRepository teamRepository;
 
@@ -30,7 +29,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
     public void createTeam(Long userId, TeamType teamType, MeetingRequestDTO.CreateTeamDTO request) {
 
         // 팀 존재하는지 확인
-        if (userTeamRepository.existsByUserIdAndTeamType(userId, teamType)) {
+        if (teamRepository.existsByTeamType(userId, teamType)) {
          throw new BusinessException(Code.TEAM_ALREADY_EXIST);
         }
 
@@ -56,6 +55,11 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         teamRepository.save(newTeam);
 
         for(Long teamMemberId : request.getTeamMember()) {
+
+            // 팀 존재하는지 확인
+            if (teamRepository.existsByTeamType(teamMemberId, teamType)) {
+                throw new BusinessException(Code.TEAM_ALREADY_EXIST);
+            }
 
             User user = userRepository.findById(teamMemberId).get();
             if (user.getUserProfile().getGender() != gender) {

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -27,6 +27,12 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
     @Transactional
     public void createTeam(Long userId, TeamType teamType, MeetingRequestDTO.CreateTeamDTO request) {
 
+        // 닉네임 중복 확인
+        if (teamRepository.existsByName(request.getName())) {
+            throw new BusinessException(Code.NAME_ALREADY_EXIST);
+        }
+
+        // 팀원 수 확인
         int userCount = request.getTeamMember().size();
         if (teamType == TeamType.TWO_TO_TWO && userCount != 2) {
             throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
@@ -48,7 +54,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
             if (user.getUserProfile().getGender() != gender) {
                 throw new BusinessException(Code.TEAM_GENDER_MISMATCH);
             }
-            MeetingConverter.toCreateUserTeam(user, newTeam);
+            MeetingConverter.toUserTeam(user, newTeam);
         }
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.TeamType;
 import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
+import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
 import com.gdg.z_meet.domain.user.repository.UserProfileRepository;
@@ -20,12 +21,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingCommandServiceImpl implements MeetingCommandService {
 
     private final UserRepository userRepository;
+    private final UserTeamRepository userTeamRepository;
     private final UserProfileRepository userProfileRepository;
     private final TeamRepository teamRepository;
 
     @Override
     @Transactional
     public void createTeam(Long userId, TeamType teamType, MeetingRequestDTO.CreateTeamDTO request) {
+
+        // 팀 존재하는지 확인
+        if (userTeamRepository.existsByUserIdAndTeamType(userId, teamType)) {
+         throw new BusinessException(Code.TEAM_ALREADY_EXIST);
+        }
 
         // 닉네임 중복 확인
         if (teamRepository.existsByName(request.getName())) {

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -70,9 +71,12 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
     @Transactional(readOnly = true)
     public MeetingResponseDTO.GetMyTeamDTO getPreMyTeam(Long userId, TeamType teamType) {
 
-        Team team = teamRepository.findByTeamType(userId, teamType)
-                .orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
+        Optional<Team> teamOptional = teamRepository.findByTeamType(userId, teamType);
+        if (teamOptional.isEmpty()) {
+            return null;
+        }
 
+        Team team = teamOptional.get();
         validateTeamType(team.getId(), teamType);
 
         List<UserTeam> userTeams = userTeamRepository.findByTeamId(team.getId());

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -141,10 +141,10 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
     private void validateTeamType(Long teamId, TeamType teamType) {
 
         Long userCount = userTeamRepository.countByTeamId(teamId);
-        if (teamType != TeamType.TWO_TO_TWO && userCount == 2) {
+        if (teamType == TeamType.TWO_TO_TWO && userCount != 2) {
             throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
         }
-        if (teamType != TeamType.THREE_TO_THREE && userCount == 3) {
+        if (teamType == TeamType.THREE_TO_THREE && userCount != 3) {
             throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
         }
     }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -3,12 +3,18 @@ package com.gdg.z_meet.domain.user.repository;
 import com.gdg.z_meet.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByStudentNumber(String studentNumber);
     Optional<User> findById(Long userId);
+
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.id IN :userIds")
+    List<User> findAllByIdWithProfile(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Slf4j
 @RestControllerAdvice
@@ -78,6 +79,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(InvalidDataAccessApiUsageException.class)
     public ResponseEntity<Object> handleInvalidDataAccessApiUsageException(InvalidDataAccessApiUsageException ex) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<Object> handleNoSuchElementException(NoSuchElementException ex) {
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -37,6 +37,7 @@ public enum Code implements BaseCode {
     TEAM_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4003", "팀원 수가 일치하지 않습니다."),
     INVALID_MY_TEAM_ACCESS(HttpStatus.BAD_REQUEST, "MEETING4004", "본인 팀은 조회할 수 없습니다."),
     INVALID_OTHER_TEAM_ACCESS(HttpStatus.BAD_REQUEST, "MEETING4005", "다른 팀은 조회할 수 없습니다."),
+    TEAM_GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4005", "팀의 성별과 일치하지 않습니다."),
 
     // Chat Error
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4001","채팅방을 찾을 수 없습니다."),

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -37,7 +37,8 @@ public enum Code implements BaseCode {
     TEAM_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4003", "팀원 수가 일치하지 않습니다."),
     INVALID_MY_TEAM_ACCESS(HttpStatus.BAD_REQUEST, "MEETING4004", "본인 팀은 조회할 수 없습니다."),
     INVALID_OTHER_TEAM_ACCESS(HttpStatus.BAD_REQUEST, "MEETING4005", "다른 팀은 조회할 수 없습니다."),
-    TEAM_GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4005", "팀의 성별과 일치하지 않습니다."),
+    NAME_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEETING4006", "이미 존재하는 팀명입니다."),
+    TEAM_GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4007", "팀의 성별과 일치하지 않습니다."),
 
     // Chat Error
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4001","채팅방을 찾을 수 없습니다."),

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -39,6 +39,7 @@ public enum Code implements BaseCode {
     INVALID_OTHER_TEAM_ACCESS(HttpStatus.BAD_REQUEST, "MEETING4005", "다른 팀은 조회할 수 없습니다."),
     NAME_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEETING4006", "이미 존재하는 팀명입니다."),
     TEAM_GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4007", "팀의 성별과 일치하지 않습니다."),
+    TEAM_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEETING4008", "팀이 이미 존재합니다."),
 
     // Chat Error
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4001","채팅방을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#54_team-create

## ⚡️ 작업동기

- 미팅 2대2, 3대3 팀 만들기 로직 구현

## 🔑 주요 변경사항

- POST /meeting/myTeam API 개발
- getTeamGallery 메서드 분리
- getPreMyTeam 응답에 null 추가

## 💡 관련 이슈

- #54 

![스크린샷 2025-02-14 224304](https://github.com/user-attachments/assets/d7f7daf1-188d-468a-aa63-854eca5bc9fc)
![스크린샷 2025-02-14 224319](https://github.com/user-attachments/assets/c44e6883-8b08-4060-a148-6547d796498a)
