### PR TITLE
[feat] 미팅 팀 삭제

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -94,7 +94,7 @@ public class MeetingController {
         return Response.ok(response);
     }
 
-    @Operation(summary = "팀 만들기")
+    @Operation(summary = "팀 삭제하기")
     @DeleteMapping("/myTeam")
     public Response<Void> delTeam(@RequestParam(name = "teamType") TeamType teamType) {
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -27,7 +27,7 @@ public class MeetingController {
 
     @Operation(summary = "팀 갤러리 조회", description = "12팀씩 페이징 됩니다.")
     @GetMapping
-    public Response<MeetingResponseDTO.GetTeamGalleryDTO> getTeamGallery(@RequestParam TeamType teamType, @RequestParam Integer page) {
+    public Response<MeetingResponseDTO.GetTeamGalleryDTO> getTeamGallery(@RequestParam(name = "teamType") TeamType teamType, @RequestParam(name = "page") Integer page) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         MeetingResponseDTO.GetTeamGalleryDTO response = meetingQueryService.getTeamGallery(userId, teamType, page);
@@ -47,7 +47,7 @@ public class MeetingController {
 
     @Operation(summary = "우리 팀 조회")
     @GetMapping("/myTeam")
-    public Response<MeetingResponseDTO.GetMyTeamDTO> getPreMyTeam(@RequestParam TeamType teamType) {
+    public Response<MeetingResponseDTO.GetMyTeamDTO> getPreMyTeam(@RequestParam(name = "teamType") TeamType teamType) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         MeetingResponseDTO.GetMyTeamDTO response = meetingQueryService.getPreMyTeam(userId, teamType);
@@ -57,7 +57,7 @@ public class MeetingController {
 
     @Operation(summary = "우리 팀 상세 조회")
     @GetMapping("/myTeam/detail")
-    public Response<MeetingResponseDTO.GetTeamDTO> getMyTeam(@RequestParam TeamType teamType) {
+    public Response<MeetingResponseDTO.GetTeamDTO> getMyTeam(@RequestParam(name = "teamType") TeamType teamType) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         MeetingResponseDTO.GetTeamDTO response = meetingQueryService.getMyTeam(userId, teamType);
@@ -67,7 +67,7 @@ public class MeetingController {
 
     @Operation(summary = "우리 팀 하이 개수")
     @GetMapping("/myTeam/hi")
-    public Response<MeetingResponseDTO.GetMyTeamHiDTO> getMyTeamHi(@RequestParam TeamType teamType) {
+    public Response<MeetingResponseDTO.GetMyTeamHiDTO> getMyTeamHi(@RequestParam(name = "teamType") TeamType teamType) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         MeetingResponseDTO.GetMyTeamHiDTO response = meetingQueryService.getMyTeamHi(userId, teamType);
@@ -77,7 +77,7 @@ public class MeetingController {
 
     @Operation(summary = "팀 만들기")
     @PostMapping("/myTeam")
-    public Response<Void> creatTeam(@RequestParam TeamType teamType, @RequestBody MeetingRequestDTO.CreateTeamDTO request) {
+    public Response<Void> creatTeam(@RequestParam(name = "teamType") TeamType teamType, @RequestBody MeetingRequestDTO.CreateTeamDTO request) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         meetingCommandService.createTeam(userId, teamType, request);
@@ -87,10 +87,20 @@ public class MeetingController {
 
     @Operation(summary = "팀명 중복확인")
     @GetMapping("/teamName")
-    public Response<MeetingResponseDTO.CheckNameDTO> checkName(@RequestParam @Size(min = 1, max = 7) String name) {
+    public Response<MeetingResponseDTO.CheckNameDTO> checkName(@RequestParam(name = "name") @Size(min = 1, max = 7) String name) {
 
         MeetingResponseDTO.CheckNameDTO response = meetingQueryService.checkName(name);
 
         return Response.ok(response);
+    }
+
+    @Operation(summary = "팀 만들기")
+    @DeleteMapping("/myTeam")
+    public Response<Void> delTeam(@RequestParam(name = "teamType") TeamType teamType) {
+
+        Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
+        meetingCommandService.delTeam(userId, teamType);
+
+        return Response.ok();
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -103,4 +103,14 @@ public class MeetingController {
 
         return Response.ok();
     }
+
+    @Operation(summary = "팀 삭제 기회")
+    @GetMapping("/myTeam/delete")
+    public Response<MeetingResponseDTO.GetMyDeleteDTO> getMyDelete() {
+
+        Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
+        MeetingResponseDTO.GetMyDeleteDTO response = meetingQueryService.getMyDelete(userId);
+
+        return Response.ok(response);
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -80,9 +80,9 @@ public class MeetingConverter {
                 .build();
     }
 
-    public static void toUserTeam(User user, Team team) {
+    public static UserTeam toUserTeam(User user, Team team) {
 
-        UserTeam.builder()
+        return UserTeam.builder()
                 .user(user)
                 .team(team)
                 .build();

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -87,4 +87,11 @@ public class MeetingConverter {
                 .team(team)
                 .build();
     }
+
+    public static MeetingResponseDTO.GetMyDeleteDTO toGetMyDeleteDTO(User user){
+
+        return MeetingResponseDTO.GetMyDeleteDTO.builder()
+                .leftDelete(user.getUserProfile().getLeftDelete())
+                .build();
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -89,4 +89,12 @@ public class MeetingResponseDTO {
     public static class CheckNameDTO {
         Integer check;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetMyDeleteDTO {
+        Integer leftDelete;
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -13,5 +13,6 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     List<UserTeam> findByTeamId(Long teamId);
     List<UserTeam> findByTeamIdIn(List<Long> teamIds);
     Long countByTeamId(Long id);
+    void deleteAllByTeamId(Long teamId);
 
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandService.java
@@ -6,4 +6,5 @@ import com.gdg.z_meet.domain.meeting.entity.TeamType;
 public interface MeetingCommandService {
 
     void createTeam(Long userId, TeamType teamType, MeetingRequestDTO.CreateTeamDTO request);
+    void delTeam(Long userId, TeamType teamType);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -8,6 +8,7 @@ import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
 import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.UserProfile;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
 import com.gdg.z_meet.domain.user.repository.UserProfileRepository;
 import com.gdg.z_meet.domain.user.repository.UserRepository;
@@ -79,6 +80,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
     }
 
     @Override
+    @Transactional
     public void delTeam(Long userId, TeamType teamType) {
 
         Team team = teamRepository.findByTeamType(userId, teamType)
@@ -94,10 +96,12 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         List<User> teamMembers = userRepository.findAllByIdWithProfile(new ArrayList<>(users));
 
         if (teamMembers.stream()
-                .anyMatch(user -> user.getUserProfile().getDeleteTeam() == 0)) {
+                .anyMatch(user -> user.getUserProfile().getLeftDelete() == 0)) {
             throw new BusinessException(Code.DELETE_LIMIT_EXCEEDED);
         }
 
+        userProfileRepository.subtractDelete(users);
+        userTeamRepository.deleteAllByTeamId(teamId);
         teamRepository.delete(team);
 
         if (teamRepository.existsById(teamId)) {

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -71,7 +71,11 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
                 .gender(gender)
                 .build();
         teamRepository.save(newTeam);
-        teamMembers.forEach(user -> MeetingConverter.toUserTeam(user, newTeam));
+
+        List<UserTeam> userTeams = teamMembers.stream()
+                .map(user -> MeetingConverter.toUserTeam(user, newTeam))
+                .collect(Collectors.toList());
+        userTeamRepository.saveAll(userTeams);
     }
 
     @Override

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -11,4 +11,5 @@ public interface MeetingQueryService {
     MeetingResponseDTO.GetTeamDTO getMyTeam(Long userId, TeamType teamType);
     MeetingResponseDTO.GetMyTeamHiDTO getMyTeamHi(Long userId, TeamType teamType);
     MeetingResponseDTO.CheckNameDTO checkName(String name);
+    MeetingResponseDTO.GetMyDeleteDTO getMyDelete(Long userId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -10,6 +10,7 @@ import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
 import com.gdg.z_meet.domain.user.repository.UserProfileRepository;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
 import com.gdg.z_meet.global.exception.BusinessException;
 import com.gdg.z_meet.global.response.Code;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,6 +27,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class MeetingQueryServiceImpl implements MeetingQueryService {
 
+    private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
     private final TeamRepository teamRepository;
     private final UserTeamRepository userTeamRepository;
@@ -125,6 +124,15 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
         return MeetingResponseDTO.CheckNameDTO.builder()
                 .check(exist == Boolean.TRUE ? 0 : 1)
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MeetingResponseDTO.GetMyDeleteDTO getMyDelete(Long userId) {
+
+        User user = userRepository.findByIdWithProfile(userId);
+
+        return MeetingConverter.toGetMyDeleteDTO(user);
     }
 
     private Map<Long, List<String>> collectEmoji(List<Team> teamList) {

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -62,7 +62,7 @@ public class UserProfile {
 
     @Column(nullable = false)
     @Builder.Default
-    private int deleteTeam = 0;
+    private int leftDelete = 2;
 
     @Column(nullable = false)
     @Builder.Default

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
@@ -3,6 +3,9 @@ package com.gdg.z_meet.domain.user.repository;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.entity.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +17,8 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
     List<UserProfile> findByUserIn(List<User> users);
     Optional<UserProfile> findByNickname(String nickname);
     Optional<UserProfile> findByUserId(Long userId);
+
+    @Modifying
+    @Query("UPDATE UserProfile up SET up.leftDelete = up.leftDelete - 1 WHERE up.user.id IN :userIds")
+    void subtractDelete(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -16,6 +16,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long userId);
     Optional<User> findByPhoneNumber(String phoneNumber);
 
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.id = :userId")
+    User findByIdWithProfile(@Param("userId") Long userId);
+
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.id IN :userIds")
     List<User> findAllByIdWithProfile(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdg/z_meet/global/exception/GlobalExceptionHandler.java
@@ -4,12 +4,14 @@ import com.gdg.z_meet.global.response.Code;
 import com.gdg.z_meet.global.response.Response;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -61,6 +63,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
     }
 
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
 
@@ -83,6 +93,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(Response.fail(Code.BAD_REQUEST, ex.getMessage()));
+    }
+
+    @ExceptionHandler(JpaSystemException.class)
+    public ResponseEntity<Object> handleJpaSystemException(JpaSystemException ex) {
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Response.fail(Code.INTERNAL_SERVER_ERROR, ex.getMessage()));
     }
 
     @ExceptionHandler(NoSuchElementException.class)

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -40,6 +40,8 @@ public enum Code implements BaseCode {
     NAME_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEETING4006", "이미 존재하는 팀명입니다."),
     TEAM_GENDER_MISMATCH(HttpStatus.BAD_REQUEST, "MEETING4007", "팀의 성별과 일치하지 않습니다."),
     TEAM_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MEETING4008", "팀이 이미 존재합니다."),
+    DELETE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "MEETING4009", "삭제 기회가 부족합니다."),
+    TEAM_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MEETING4010", "팀 삭제가 실패하였습니다."),
 
     // Chat Error
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4001","채팅방을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#63_team-del

## ⚡️ 작업동기

- 2대2, 3대3 미팅 팀 삭제 로직 구현

## 🔑 주요 변경사항

- DELETE /meeting/myTeam API 개발
- 팀 생성 시 userTeam 저장 안 되는 문제 해결
- 엔티티에 수정 사항이 있기 때문에, 테스트할 때 디비 업데이트 해주셔야 에러 안 납니닷
기존 deleteTeam -> leftDelete
- 해당 팀 내에서 삭제 기회가 0인 팀원이 존재할 경우, DELETE_LIMIT_EXCEEDED 에러가 발생합니다.
- GET /meeting/myTeam/delete API 개발

## 💡 관련 이슈

- #63 

<img width="880" alt="스크린샷 2025-02-17 오후 8 59 51" src="https://github.com/user-attachments/assets/94a9a514-7cdf-48c3-8922-d27f98c361f7" />
<img width="880" alt="스크린샷 2025-02-17 오후 9 09 51" src="https://github.com/user-attachments/assets/77783af9-4778-4fde-9093-182196738086" />
