### PR TITLE
랜덤미팅 남은 티켓 개수 조회하는 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 .env
 nginx.conf
+
+### Mac OS ###
+.DS_Store

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/RandomController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/RandomController.java
@@ -1,17 +1,11 @@
 package com.gdg.z_meet.domain.meeting.controller;
 
-import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
-import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.dto.RandomResponseDTO;
-import com.gdg.z_meet.domain.meeting.entity.TeamType;
-import com.gdg.z_meet.domain.meeting.service.MeetingCommandService;
-import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
+import com.gdg.z_meet.domain.meeting.service.RandomQueryService;
 import com.gdg.z_meet.global.common.AuthenticatedUserUtils;
 import com.gdg.z_meet.global.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -23,15 +17,14 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 public class RandomController {
 
-    private final MeetingQueryService meetingQueryService;
-    private final MeetingCommandService meetingCommandService;
+    private final RandomQueryService randomQueryService;
 
     @Operation(summary = "남은 티켓 개수")
     @GetMapping("/ticket")
-    public Response<RandomResponseDTO.GetTicketDTO> getMyDelete() {
+    public Response<RandomResponseDTO.GetTicketDTO> getTicket() {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
-        RandomResponseDTO.GetTicketDTO response;
+        RandomResponseDTO.GetTicketDTO response = randomQueryService.getTicket(userId);
 
         return Response.ok(response);
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/RandomController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/RandomController.java
@@ -1,0 +1,38 @@
+package com.gdg.z_meet.domain.meeting.controller;
+
+import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
+import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
+import com.gdg.z_meet.domain.meeting.dto.RandomResponseDTO;
+import com.gdg.z_meet.domain.meeting.entity.TeamType;
+import com.gdg.z_meet.domain.meeting.service.MeetingCommandService;
+import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
+import com.gdg.z_meet.global.common.AuthenticatedUserUtils;
+import com.gdg.z_meet.global.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/random")
+@Tag(name = "RandomMeeting")
+@Validated
+public class RandomController {
+
+    private final MeetingQueryService meetingQueryService;
+    private final MeetingCommandService meetingCommandService;
+
+    @Operation(summary = "남은 티켓 개수")
+    @GetMapping("/ticket")
+    public Response<RandomResponseDTO.GetTicketDTO> getMyDelete() {
+
+        Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
+        RandomResponseDTO.GetTicketDTO response;
+
+        return Response.ok(response);
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/RandomConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/RandomConverter.java
@@ -1,0 +1,14 @@
+package com.gdg.z_meet.domain.meeting.converter;
+
+import com.gdg.z_meet.domain.meeting.dto.RandomResponseDTO;
+import com.gdg.z_meet.domain.user.entity.User;
+
+public class RandomConverter {
+
+    public static RandomResponseDTO.GetTicketDTO toGetTicketDTO(User user){
+
+        return RandomResponseDTO.GetTicketDTO.builder()
+                .ticket(user.getUserProfile().getTicket())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/RandomResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/RandomResponseDTO.java
@@ -1,0 +1,19 @@
+package com.gdg.z_meet.domain.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class RandomResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetTicketDTO {
+        Integer ticket;
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomQueryService.java
@@ -1,0 +1,8 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.dto.RandomResponseDTO;
+
+public interface RandomQueryService {
+
+    RandomResponseDTO.GetTicketDTO getTicket(Long userId);
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomQueryServiceImpl.java
@@ -1,0 +1,25 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.converter.RandomConverter;
+import com.gdg.z_meet.domain.meeting.dto.RandomResponseDTO;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RandomQueryServiceImpl implements RandomQueryService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public RandomResponseDTO.GetTicketDTO getTicket(Long userId) {
+
+        User user = userRepository.findByIdWithProfile(userId);
+
+        return RandomConverter.toGetTicketDTO(user);
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -67,6 +67,10 @@ public class UserProfile {
     @Builder.Default
     private Level level = LIGHT;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int ticket = 2;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#70_ticket

## ⚡️ 작업동기

- 랜덤미팅 남은 티켓 개수 조회하는 로직 구현

## 🔑 주요 변경사항

- GET /random/ticket API 개발

## 💡 관련 이슈

- #70 

<img width="650" alt="스크린샷 2025-02-19 오전 3 45 36" src="https://github.com/user-attachments/assets/c8597e7d-80cd-48a2-b8d2-e3451854e9a9" />
