### PR TITLE
[Fix] #88: 하이 조회시 상대방 팀과 내 팀 ID를 조회할 수 있도록 수정

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -97,6 +97,8 @@ public class MeetingResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class hiListDto {
+        Long myTeamId;
+        Long teamId;
         String teamName;
         List<UserProfileDto> teamList;
         Double age;

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
@@ -141,6 +141,7 @@ public class HiQueryServiceImpl implements HiQueryService{
             if(hi.getHiStatus()!=HiStatus.NONE && action.equals("Receive")) continue;
 
             Team team = action.equals("Receive") ? hi.getFrom() : hi.getTo();
+            Team myteam = action.equals("Receive") ? hi.getTo() : hi.getFrom();
 
             // UserProfileDto 생성 (null 방지)
             String major = String.join(", ", majorList.getOrDefault(team.getId(), Collections.emptyList()));
@@ -178,7 +179,7 @@ public class HiQueryServiceImpl implements HiQueryService{
 
                 dateTime = String.format("%d시간 %d분 남음", remainingHours, remainingMinutes);
 
-                if(remainingHours<=0 || remainingMinutes<=0){
+                if(remainingHours<=0 || remainingMinutes<0){
                     hi.changeStatus(HiStatus.EXPIRED);
                     hiRepository.save(hi);
                     continue;
@@ -187,6 +188,8 @@ public class HiQueryServiceImpl implements HiQueryService{
 
             // 하나의 hiListDto 생성
             MeetingResponseDTO.hiListDto hiDto = MeetingResponseDTO.hiListDto.builder()
+                    .myTeamId(myteam.getId())
+                    .teamId(team.getId())
                     .teamName(team.getName())
                     .teamList(userProfileDtos)
                     .age(Math.round(age.get(team.getId()) * 10.0) / 10.0)


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix#88-hi-dto

## ⚡️ 작업동기

-  하이 dto 수정

## 🔑 주요 변경사항

- 하이 조회시 상대방 팀과 내 팀 ID를 조회할 수 있도록 수정 (보낸하이/받은하이)

## 💡 관련 이슈

- #88