### PR TITLE
[#100] Fix: 채팅방 내 사용자 조회시 상대방 이름이 나오는 오류수정

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
@@ -218,9 +218,11 @@ public class ChatRoomQueryService {
 
         List<UserTeam> userTeams = userTeamRepository.findByTeamIdIn(teamIds);
 
+        // 유저 프로필 맵으로 전환
         Map<Long, ChatRoomDto.UserProfileDto> userProfileMap = userProfileDtos.stream()
                 .collect(Collectors.toMap(ChatRoomDto.UserProfileDto::getUserId, Function.identity()));
 
+        // 팀별 유저 리스트 맵핑
         Map<Long, List<Long>> teamUserMap = userTeams.stream()
                 .collect(Collectors.groupingBy(
                         userTeam -> userTeam.getTeam().getId(),
@@ -228,9 +230,16 @@ public class ChatRoomQueryService {
                 ));
 
         List<ChatRoomDto.chatRoomUserList> teamUserLists = new ArrayList<>();
+
         for (TeamChatRoom teamChatRoom : teamChatRooms) {
             Long teamId = teamChatRoom.getTeam().getId();
-            String teamName = teamChatRoom.getName();
+
+            // 상대방 팀의 이름 추출
+            String teamName = teamChatRooms.stream()
+                    .filter(tc -> !tc.getTeam().getId().equals(teamId))  // 현재 teamChatRoom이 아닌 것 선택
+                    .map(TeamChatRoom::getName)  // 이름 추출
+                    .findFirst()  // 상대방 이름 가져오기
+                    .orElse("알 수 없는 팀");  // 혹시라도 2개가 아닐 경우 대비
 
             List<Long> teamUserIds = teamUserMap.getOrDefault(teamId, Collections.emptyList());
             List<ChatRoomDto.UserProfileDto> teamUsers = teamUserIds.stream()


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix/#100-chatroom-users-read

## ⚡️ 작업동기

- 프론트파트장님 요청

## 🔑 주요 변경사항

- 채팅방 내 사용자 조회시 상대방 이름이 나오는 오류수정

## 💡 관련 이슈

- #100