### PR TITLE
[#104] Fix: 사용자 조회시 닉네임이 조회되도록 설정

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
@@ -173,8 +173,8 @@ public class ChatRoomQueryService {
                 .map(userProfile -> {
                     // 사용자 ID가 동일한 경우 이름에 "(나)" 추가
                     String userName = userProfile.getUser().getId().equals(userId)
-                            ? userProfile.getUser().getName() + "(나)"
-                            : userProfile.getUser().getName();
+                            ? userProfile.getUser().getUserProfile().getNickname() + "(나)"
+                            : userProfile.getUser().getUserProfile().getNickname();
 
                     return new ChatRoomDto.UserProfileDto(
                             userProfile.getUser().getId(),


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix#104-chatroom-user-list

## ⚡️ 작업동기

- 프론트팀장님 요청

## 🔑 주요 변경사항

- 사용자 조회시 닉네임이 조회되도록 설정

## 💡 관련 이슈

- #104