### PR TITLE
#108 [feat] 로그인 상태확인 api 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
@@ -85,4 +85,31 @@ public class UserController {
         userService.withdraw(userId, response);
         return Response.ok(null);
     }
+
+    @GetMapping("/check-login")
+    public Response<UserRes.CheckLoginRes> checkLogin(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = jwtUtil.getAccessToken(request);
+        if (accessToken != null && jwtUtil.validateToken(request, accessToken)) {
+            return Response.ok(UserRes.CheckLoginRes.builder()
+                    .isLoggedIn(true)
+                    .accessToken(accessToken)
+                    .build());
+        } else {
+            String refreshToken = jwtUtil.getRefreshTokenFromCookie(request);
+            if (refreshToken != null && jwtUtil.validateRefreshToken(refreshToken)) {
+                String studentNumber = jwtUtil.getStudentNumberFromToken(refreshToken);
+                Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+                String newAccessToken = jwtUtil.getToken(studentNumber, userId, new java.util.Date(), jwtUtil.getAccessTokenValidTime());
+                response.setHeader("Authorization", "Bearer " + newAccessToken);
+                return Response.ok(UserRes.CheckLoginRes.builder()
+                        .isLoggedIn(true)
+                        .accessToken(newAccessToken)
+                        .build());
+            }
+        }
+        return Response.ok(UserRes.CheckLoginRes.builder()
+                .isLoggedIn(false)
+                .accessToken(null)
+                .build());
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/dto/UserRes.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/dto/UserRes.java
@@ -77,4 +77,11 @@ public class UserRes {
     public static class EmojiUpdateRes {
         private String emoji;
     }
+
+    @Getter
+    @Builder
+    public static class CheckLoginRes {
+        private boolean isLoggedIn;
+        private String accessToken;
+    }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #108 

## ⚡️ 작업동기

- 액세스 만료 시 리프레쉬를 이용해 액세스 발급하는 api 추가

## 🔑 주요 변경사항

- 액세스가 존재 시 로그인 중임을 반환
- 액세스가 만료된 상태에서 쿠키에 있는 리프레쉬를 이용해 액세스 재발급 후 로그인 중임을 확인

## 💡 관련 이슈

- #108 