### PR TITLE
[fix] 팀원 추가 로직 수정

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -130,11 +130,12 @@ public class MeetingController {
 
     @Operation(summary = "팀원 검색하기")
     @GetMapping("/search")
-    public Response<MeetingResponseDTO.GetSearchListDTO> getSearch(@RequestParam(name = "nickname", required = false) @Size(min = 1, max = 8) String nickname,
-                                                               @RequestParam(name = "phoneNumber", required = false) @Size(min = 1, max = 11) String phoneNumber) {
+    public Response<MeetingResponseDTO.GetSearchListDTO> getSearch(@RequestParam(name = "teamType") TeamType teamType,
+                                                                   @RequestParam(name = "nickname", required = false) @Size(min = 1, max = 8) String nickname,
+                                                                   @RequestParam(name = "phoneNumber", required = false) @Size(min = 1, max = 11) String phoneNumber) {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
-        MeetingResponseDTO.GetSearchListDTO response = meetingQueryService.getSearch(userId, nickname, phoneNumber);
+        MeetingResponseDTO.GetSearchListDTO response = meetingQueryService.getSearch(userId, teamType, nickname, phoneNumber);
 
         return Response.ok(response);
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -11,6 +11,6 @@ public interface MeetingQueryService {
     MeetingResponseDTO.GetMyTeamDTO getMyTeam(Long userId, TeamType teamType);
     MeetingResponseDTO.GetMyTeamHiDTO getMyTeamHi(Long userId, TeamType teamType);
     MeetingResponseDTO.CheckNameDTO checkName(String name);
-    MeetingResponseDTO.GetSearchListDTO getSearch(Long userId, String nickname, String phoneNumber);
+    MeetingResponseDTO.GetSearchListDTO getSearch(Long userId, TeamType teamType, String nickname, String phoneNumber);
     MeetingResponseDTO.GetMyDeleteDTO getMyDelete(Long userId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -138,7 +138,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public MeetingResponseDTO.GetSearchListDTO getSearch(Long userId, String nickname, String phoneNumber) {
+    public MeetingResponseDTO.GetSearchListDTO getSearch(Long userId, TeamType teamType, String nickname, String phoneNumber) {
 
         if (nickname == null && phoneNumber == null) {
             throw new BusinessException(Code.SEARCH_FILTER_NULL);
@@ -151,9 +151,9 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
         List<User> users;
 
         if (nickname != null) {
-            users = userRepository.findAllByNicknameContainingWithProfile(gender, nickname, userId);
+            users = userRepository.findAllByNicknameWithProfile(gender, nickname, userId, teamType);
         } else if (phoneNumber.length() >= 7) {
-            users = userRepository.findAllByPhoneNumberContainingWithProfile(gender, phoneNumber, userId);
+            users = userRepository.findAllByPhoneNumberWithProfile(gender, phoneNumber, userId);
         } else {
             users = Collections.emptyList();
         }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -151,7 +151,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
         List<User> users;
 
         if (nickname != null) {
-            users = userRepository.findAllByNicknameContainingWithProfile(gender, nickname);
+            users = userRepository.findAllByNicknameContainingWithProfile(gender, nickname, userId);
         } else {
             users = userRepository.findAllByPhoneNumberContainingWithProfile(gender, phoneNumber);
         }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -152,8 +152,10 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
 
         if (nickname != null) {
             users = userRepository.findAllByNicknameContainingWithProfile(gender, nickname, userId);
+        } else if (phoneNumber.length() >= 7) {
+            users = userRepository.findAllByPhoneNumberContainingWithProfile(gender, phoneNumber, userId);
         } else {
-            users = userRepository.findAllByPhoneNumberContainingWithProfile(gender, phoneNumber);
+            users = Collections.emptyList();
         }
         return MeetingConverter.GetSearchListDTO(users);
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -153,7 +153,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
         if (nickname != null) {
             users = userRepository.findAllByNicknameWithProfile(gender, nickname, userId, teamType);
         } else if (phoneNumber.length() >= 7) {
-            users = userRepository.findAllByPhoneNumberWithProfile(gender, phoneNumber, userId);
+            users = userRepository.findAllByPhoneNumberWithProfile(gender, phoneNumber, userId, teamType);
         } else {
             users = Collections.emptyList();
         }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -24,8 +24,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.id IN :userIds")
     List<User> findAllByIdWithProfile(@Param("userIds") List<Long> userIds);
 
-    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND up.nickname LIKE %:nickname%")
-    List<User> findAllByNicknameContainingWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname);
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND up.nickname LIKE :nickname% AND u.id != :userId")
+    List<User> findAllByNicknameContainingWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname, @Param("userId") Long userId);
 
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND u.phoneNumber LIKE %:phoneNumber%")
     List<User> findAllByPhoneNumberContainingWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber);

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -27,6 +27,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND up.nickname LIKE :nickname% AND u.id != :userId")
     List<User> findAllByNicknameContainingWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname, @Param("userId") Long userId);
 
-    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND u.phoneNumber LIKE %:phoneNumber%")
-    List<User> findAllByPhoneNumberContainingWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber);
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND u.phoneNumber LIKE :phoneNumber% AND u.id != :userId")
+    List<User> findAllByPhoneNumberContainingWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber, @Param("userId") Long userId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.gdg.z_meet.domain.user.repository;
 
+import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,9 +25,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.id IN :userIds")
     List<User> findAllByIdWithProfile(@Param("userIds") List<Long> userIds);
 
-    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND up.nickname LIKE :nickname% AND u.id != :userId")
-    List<User> findAllByNicknameContainingWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname, @Param("userId") Long userId);
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
+            "AND up.nickname LIKE :nickname% AND u.id != :userId " +
+            "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
+            "WHERE ut.user = u AND t.teamType = :teamType)")
+    List<User> findAllByNicknameWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname, @Param("userId") Long userId, @Param("teamType") TeamType teamType);
 
-    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender AND u.phoneNumber LIKE :phoneNumber% AND u.id != :userId")
-    List<User> findAllByPhoneNumberContainingWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber, @Param("userId") Long userId);
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
+            "AND u.phoneNumber LIKE :phoneNumber% AND u.id != :userId")
+    List<User> findAllByPhoneNumberWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber, @Param("userId") Long userId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -32,6 +32,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllByNicknameWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname, @Param("userId") Long userId, @Param("teamType") TeamType teamType);
 
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
-            "AND u.phoneNumber LIKE :phoneNumber% AND u.id != :userId")
-    List<User> findAllByPhoneNumberWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber, @Param("userId") Long userId);
+            "AND u.phoneNumber LIKE :phoneNumber% AND u.id != :userId " +
+            "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
+            "WHERE ut.user = u AND t.teamType = :teamType)")
+    List<User> findAllByPhoneNumberWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber, @Param("userId") Long userId, @Param("teamType") TeamType teamType);
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix/#107_team-search

## ⚡️ 작업동기

- 미팅 2대2, 3대3 팀 생성 시 팀원 추가(검색) 로직 수정

## 🔑 주요 변경사항

- /meeting/search API 수정
- 본인 조회 안 되도록 수정
- 팀 존재하는 유저 조회 안 되도록 수정
- 검색어 포함 데이터 X, 검색어로 시작하는 데이터만 조회되도록 수정

## 💡 관련 이슈

- #107 

<img width="600" alt="스크린샷 2025-03-12 오전 3 10 31" src="https://github.com/user-attachments/assets/323b5171-fbca-492e-8672-ea8
<img width="600" alt="스크린샷 2025-03-12 오전 3 13 48" src="https://github.com/user-attachments/assets/97f4712c-508d-4643-ac0a-09e2eccc5802" />
014be6980" />
