### PR TITLE
[feat] 리프레시 토큰 DB에 저장

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.gdg.z_meet.domain.user.controller;
 
-import com.gdg.z_meet.global.exception.GlobalException;
 import com.gdg.z_meet.global.jwt.JwtUtil;
 import com.gdg.z_meet.global.response.Response;
 import com.gdg.z_meet.domain.user.dto.Token;
@@ -81,26 +80,16 @@ public class UserController {
     @Operation(summary = "회원탈퇴", description = "회원탈퇴")
     public Response<Void> withdraw(HttpServletRequest request, HttpServletResponse response) {
         Long userId = jwtUtil.extractUserIdFromRequest(request);
-        userService.withdraw(userId, response);
+        userService.withdraw(userId, request, response);
         return Response.ok(null);
     }
 
     @GetMapping("/check-login")
-    public Response<UserRes.CheckLoginRes> checkLogin(HttpServletRequest request, HttpServletResponse response) {
+    public Response<UserRes.CheckLoginRes> checkLogin(HttpServletRequest request) {
         String accessToken = jwtUtil.getAccessToken(request);
-
         if (accessToken != null && jwtUtil.validateToken(request, accessToken)) {
             Long userId = jwtUtil.extractUserIdFromRequest(request);
             return Response.ok(UserRes.CheckLoginRes.loggedIn(userId, accessToken));
-        } else {
-            String refreshToken = jwtUtil.getRefreshTokenFromCookie(request);
-            if (refreshToken != null && jwtUtil.validateRefreshToken(refreshToken)) {
-                String studentNumber = jwtUtil.getStudentNumberFromToken(refreshToken);
-                Long userId = jwtUtil.getUserIdFromToken(refreshToken);
-                String newAccessToken = jwtUtil.getToken(studentNumber, userId, new java.util.Date(), jwtUtil.getAccessTokenValidTime());
-                response.setHeader("Authorization", "Bearer " + newAccessToken);
-                return Response.ok(UserRes.CheckLoginRes.refreshed(userId, newAccessToken));
-            }
         }
         return Response.ok(UserRes.CheckLoginRes.loggedOut());
     }

--- a/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
@@ -41,9 +41,8 @@ public class UserController {
 
     @DeleteMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃")
-    public Response<Void> logout(HttpServletResponse response, HttpServletRequest request) {
-        String accessToken = jwtUtil.extractTokenFromHeader(request.getHeader("Authorization"));
-        userService.logout(response, accessToken);
+    public Response<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        userService.logout(request, response);
         return Response.ok(null);
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,30 @@
+package com.gdg.z_meet.domain.user.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class RefreshTokenRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    public RefreshTokenRepository(@Qualifier("matchingRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String token, Long userId, long ttl) {
+        redisTemplate.opsForValue().set(token, userId.toString(), ttl, TimeUnit.SECONDS);
+    }
+
+    public String findByToken(String token) {
+        return redisTemplate.opsForValue().get(token);
+    }
+
+    public void delete(String token) {
+        redisTemplate.delete(token);
+    }
+}

--- a/src/main/java/com/gdg/z_meet/global/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -40,7 +41,7 @@ public class SecurityConfig {
                         .requestMatchers("/ws", "/ws/**", "/ws/info/**").permitAll()  // WebSocket 엔드포인트 허용
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #119 

## ⚡️ 작업동기

- 리프레시 토큰 저장이 필요해져 재구현

## 🔑 주요 변경사항

- 리프레시 레디스에 저장
- 리프레시만 있을 때 api 실행 시 액세스를 header -> authorization으로 넣어 검증

## 💡 관련 이슈

- #119 