### PR TITLE
[feat] 팀 상태 컬럼 추가

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
@@ -1,5 +1,6 @@
 package com.gdg.z_meet.domain.meeting.entity;
 
+import com.gdg.z_meet.domain.meeting.entity.enums.ActiveStatus;
 import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
 import com.gdg.z_meet.domain.meeting.entity.enums.Verification;
 import com.gdg.z_meet.global.common.BaseEntity;
@@ -42,6 +43,11 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private Verification verification = Verification.NONE;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private ActiveStatus activeStatus = ActiveStatus.ACTIVE;
 
     // hi 값을 변경하는 메서드
     public void decreaseHi() {

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
@@ -61,4 +61,8 @@ public class Team extends BaseEntity {
     public void increaseHi(int amount) {
         this.hi += amount;
     }
+
+    public void inactivateTeam() {
+        this.activeStatus = ActiveStatus.INACTIVE;
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/enums/ActiveStatus.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/enums/ActiveStatus.java
@@ -1,0 +1,5 @@
+package com.gdg.z_meet.domain.meeting.entity.enums;
+
+public enum ActiveStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -5,6 +5,7 @@ import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -30,4 +31,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "JOIN UserTeam ut ON ut.team = t " +
             "WHERE ut.user.id IN :userIds AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE'")
     Boolean existsAnyMemberByTeamType(@Param("userIds") List<Long> userIds, @Param("teamType") TeamType teamType);
+
+    @Query("UPDATE Team t SET t.activeStatus = 'INACTIVE' WHERE t = :team")
+    @Modifying
+    void deleteByTeam(Team team);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -32,7 +32,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "WHERE ut.user.id IN :userIds AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE'")
     Boolean existsAnyMemberByTeamType(@Param("userIds") List<Long> userIds, @Param("teamType") TeamType teamType);
 
-    @Query("UPDATE Team t SET t.activeStatus = 'INACTIVE' WHERE t = :team")
-    @Modifying
-    void deleteByTeam(Team team);
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM Team t " +
+            "WHERE t.id = :teamId AND t.activeStatus = 'ACTIVE'")
+    Boolean existsByIdAndActiveStatus(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -14,19 +14,20 @@ import java.util.Optional;
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t WHERE t.id NOT IN (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId) " +
-            "AND t.gender != :gender AND t.teamType = :teamType")
+            "AND t.gender != :gender AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE'")
     List<Team> findAllByTeamType(@Param("userId") Long userId, @Param("gender") Gender gender, @Param("teamType") TeamType teamType, Pageable pageable);
 
     @Query("SELECT t FROM Team t WHERE t.id IN (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId) " +
-            "AND t.teamType = :teamType")
+            "AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE'")
     Optional<Team> findByTeamType(@Param("userId") Long userId, @Param("teamType") TeamType teamType);
 
-    Boolean existsByName(String name);
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM Team t WHERE t.name = :name AND t.activeStatus = 'ACTIVE'")
+    Boolean existsByName(@Param("name") String name);
 
     List<Team> findByIdIn(List<Long> teamIds);
 
     @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM Team t " +
             "JOIN UserTeam ut ON ut.team = t " +
-            "WHERE ut.user.id IN :userIds AND t.teamType = :teamType")
+            "WHERE ut.user.id IN :userIds AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE'")
     Boolean existsAnyMemberByTeamType(@Param("userIds") List<Long> userIds, @Param("teamType") TeamType teamType);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -3,17 +3,27 @@ package com.gdg.z_meet.domain.meeting.repository;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
-    boolean existsByUserIdAndTeamId(Long userId, Long teamId);
-    List<UserTeam> findByTeamId(Long teamId);
-    List<UserTeam> findByTeamIdIn(List<Long> teamIds);
-    Long countByTeamId(Long id);
-    void deleteAllByTeamId(Long teamId);
-    List<UserTeam> findByUserId(Long userId);
-    List<UserTeam> findByUser(User user);
+    @Query("SELECT CASE WHEN COUNT(ut) > 0 THEN true ELSE false END FROM UserTeam ut WHERE ut.user.id = :userId AND ut.team.id = :teamId AND ut.team.activeStatus = 'ACTIVE'")
+    boolean existsByUserIdAndTeamId(@Param("userId") Long userId, @Param("teamId") Long teamId);
 
+    @Query("SELECT ut FROM UserTeam ut WHERE ut.team.id = :teamId AND ut.team.activeStatus = 'ACTIVE'")
+    List<UserTeam> findByTeamId(@Param("teamId") Long teamId);
+
+    List<UserTeam> findByTeamIdIn(List<Long> teamIds);
+
+    @Query("SELECT COUNT(ut) FROM UserTeam ut WHERE ut.team.id = :teamId AND ut.team.activeStatus = 'ACTIVE'")
+    Long countByTeamId(@Param("teamId") Long teamId);
+
+    @Query("SELECT ut FROM UserTeam ut WHERE ut.user.id = :userId AND ut.team.activeStatus = 'ACTIVE'")
+    List<UserTeam> findByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT ut FROM UserTeam ut WHERE ut.user = :user AND ut.team.activeStatus = 'ACTIVE'")
+    List<UserTeam> findByUser(@Param("user") User user);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -11,14 +11,18 @@ import java.util.List;
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     @Query("SELECT CASE WHEN COUNT(ut) > 0 THEN true ELSE false END FROM UserTeam ut WHERE ut.user.id = :userId AND ut.team.id = :teamId AND ut.team.activeStatus = 'ACTIVE'")
-    boolean existsByUserIdAndTeamId(@Param("userId") Long userId, @Param("teamId") Long teamId);
+    boolean existsByUserIdAndTeamIdAndActiveStatus(@Param("userId") Long userId, @Param("teamId") Long teamId);
+
+    boolean existsByUserIdAndTeamId(Long userId, Long teamId);
 
     @Query("SELECT ut FROM UserTeam ut WHERE ut.team.id = :teamId AND ut.team.activeStatus = 'ACTIVE'")
-    List<UserTeam> findByTeamId(@Param("teamId") Long teamId);
+    List<UserTeam> findByTeamIdAndActiveStatus(@Param("teamId") Long teamId);
+
+    List<UserTeam> findByTeamId(Long teamId);
 
     List<UserTeam> findByTeamIdIn(List<Long> teamIds);
 
-    @Query("SELECT COUNT(ut) FROM UserTeam ut WHERE ut.team.id = :teamId AND ut.team.activeStatus = 'ACTIVE'")
+    @Query("SELECT COUNT(ut) FROM UserTeam ut WHERE ut.team.id = :teamId")
     Long countByTeamId(@Param("teamId") Long teamId);
 
     @Query("SELECT ut FROM UserTeam ut WHERE ut.user.id = :userId AND ut.team.activeStatus = 'ACTIVE'")

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -100,7 +100,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         }
 
         userProfileRepository.subtractDelete(users);
-        teamRepository.delete(team);
+        teamRepository.deleteByTeam(team);
 
         if (teamRepository.existsById(teamId)) {
             throw new BusinessException(Code.TEAM_DELETE_FAILED);

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -100,9 +100,10 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         }
 
         userProfileRepository.subtractDelete(users);
-        teamRepository.deleteByTeam(team);
+        team.inactivateTeam();
+        teamRepository.save(team);
 
-        if (teamRepository.existsById(teamId)) {
+        if (teamRepository.existsByIdAndActiveStatus(teamId)) {
             throw new BusinessException(Code.TEAM_DELETE_FAILED);
         }
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -100,7 +100,6 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         }
 
         userProfileRepository.subtractDelete(users);
-        userTeamRepository.deleteAllByTeamId(teamId);
         teamRepository.delete(team);
 
         if (teamRepository.existsById(teamId)) {

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -87,7 +87,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         Long teamId = team.getId();
 
         // 삭제 기회 확인
-        List<UserTeam> userTeams = userTeamRepository.findByTeamId(teamId);
+        List<UserTeam> userTeams = userTeamRepository.findByTeamIdAndActiveStatus(teamId);
         List<Long> users = userTeams.stream()
                 .map(UserTeam -> UserTeam.getUser().getId())
                 .collect(Collectors.toList());

--- a/src/main/java/com/gdg/z_meet/domain/order/service/KaKaoPayService.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/service/KaKaoPayService.java
@@ -52,7 +52,7 @@ public class KaKaoPayService {
         User buyer = userRepository.findById(parameter.getBuyerId()).orElseThrow(() -> new BusinessException(Code.MEMBER_NOT_FOUND));
 
         if (!ProductType.valueOf(parameter.getProductType()).equals(ProductType.TICKET) && !ProductType.valueOf(parameter.getProductType()).equals(ProductType.SEASON)) {
-                boolean isMember = userTeamRepository.existsByUserIdAndTeamId(parameter.getBuyerId(), parameter.getTeamId());
+                boolean isMember = userTeamRepository.existsByUserIdAndTeamIdAndActiveStatus(parameter.getBuyerId(), parameter.getTeamId());
             if (!isMember) {
                 throw new BusinessException(Code.TEAM_USER_NOT_FOUND);
             }

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -46,6 +46,7 @@ public enum Code implements BaseCode {
     SEARCH_FILTER_NULL(HttpStatus.BAD_REQUEST, "MEETING4011", "검색 조건이 없습니다."),
     SEARCH_FILTER_EXCEEDED(HttpStatus.BAD_REQUEST, "MEETING4012", "검색 조건은 한 가지만 가능합니다."),
     RANDOM_MEETING_USER_COUNT(HttpStatus.BAD_REQUEST, "CHAT4005",  "랜덤 미팅에 참여하는 사용자 수는 반드시 6명이어야 합니다."),
+    TEAM_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "MEETING4013", "삭제된 팀입니다."),
 
     //Matching Error
     MATCHING_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "MATCHING4001", "이미 랜덤 매칭중입니다."),


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#122_team-status

## ⚡️ 작업동기

- 팀 엔티티에 상태 컬럼 추가

## 🔑 주요 변경사항

- 팀이 삭제되어도 채팅은 남아있어야 하기 때문에 ActiveStatus enum 추가
- 채팅 로직 제외하고, ACTIVE한 팀만 조회하도록 수정
- 팀 삭제 요청 시 INACTIVE로 변경됨

## 💡 관련 이슈

- #122 
<img width="970" alt="스크린샷 2025-03-15 오전 5 15 13" src="https://github.com/user-attachments/assets/bdd5bcef-abd4-487a-8046-64a156912500" />
