### PR TITLE
[Refactor] 하이 삭제 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
@@ -230,6 +230,11 @@ public class ChatRoomQueryService {
                 ));
 
         List<ChatRoomDto.chatRoomUserList> teamUserLists = new ArrayList<>();
+        Long myTeamId = userTeams.stream()
+                .filter(userTeam -> userTeam.getUser().getId().equals(userId))
+                .map(userTeam -> userTeam.getTeam().getId())
+                .findFirst()
+                .orElse(null); // 현재 사용자의 팀 ID
 
         for (TeamChatRoom teamChatRoom : teamChatRooms) {
             Long teamId = teamChatRoom.getTeam().getId();
@@ -253,6 +258,10 @@ public class ChatRoomQueryService {
                     .userProfiles(teamUsers)
                     .build());
         }
+        //우리팀을 첫번째로 배치
+        if (myTeamId != null) {
+            teamUserLists.sort(Comparator.comparing(team -> !team.getTeamId().equals(myTeamId)));
+        }
 
         return teamUserLists;
     }
@@ -273,18 +282,20 @@ public class ChatRoomQueryService {
                 .filter(profile -> profile.getGender() != user.getUserProfile().getGender()) // 이성 팀
                 .collect(Collectors.toList());
 
-        // 사용자 목록을 성별에 따라 나눠서 반환
-        return Arrays.asList(
-                ChatRoomDto.chatRoomUserList.builder()
-                        .teamId(null)
-                        .teamName("이성팀")
-                        .userProfiles(anotherTeamUsers)
-                        .build(),
-                ChatRoomDto.chatRoomUserList.builder()
-                        .teamId(null)
-                        .teamName("내 팀")
-                        .userProfiles(myTeamUsers)
-                        .build()
-        );
+        List<ChatRoomDto.chatRoomUserList> sortedUserLists = new ArrayList<>();
+
+        sortedUserLists.add(ChatRoomDto.chatRoomUserList.builder()
+                .teamId(null)
+                .teamName("내 팀") // 내 팀을 항상 첫 번째로 배치
+                .userProfiles(myTeamUsers)
+                .build());
+
+        sortedUserLists.add(ChatRoomDto.chatRoomUserList.builder()
+                .teamId(null)
+                .teamName("이성 팀")
+                .userProfiles(anotherTeamUsers)
+                .build());
+
+        return sortedUserLists;
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
@@ -244,7 +244,7 @@ public class ChatRoomQueryService {
                     .filter(tc -> !tc.getTeam().getId().equals(teamId))  // 현재 teamChatRoom이 아닌 것 선택
                     .map(TeamChatRoom::getName)  // 이름 추출
                     .findFirst()  // 상대방 이름 가져오기
-                    .orElse("알 수 없는 팀");  // 혹시라도 2개가 아닐 경우 대비
+                    .orElse("알 수 없는");  // 혹시라도 2개가 아닐 경우 대비
 
             List<Long> teamUserIds = teamUserMap.getOrDefault(teamId, Collections.emptyList());
             List<ChatRoomDto.UserProfileDto> teamUsers = teamUserIds.stream()
@@ -286,13 +286,13 @@ public class ChatRoomQueryService {
 
         sortedUserLists.add(ChatRoomDto.chatRoomUserList.builder()
                 .teamId(null)
-                .teamName("내 팀") // 내 팀을 항상 첫 번째로 배치
+                .teamName("내 ") // 내 팀을 항상 첫 번째로 배치
                 .userProfiles(myTeamUsers)
                 .build());
 
         sortedUserLists.add(ChatRoomDto.chatRoomUserList.builder()
                 .teamId(null)
-                .teamName("이성 팀")
+                .teamName("이성 ")
                 .userProfiles(anotherTeamUsers)
                 .build());
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/enums/HiStatus.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/enums/HiStatus.java
@@ -1,5 +1,5 @@
 package com.gdg.z_meet.domain.meeting.entity.enums;
 
 public enum HiStatus {
-    NONE, ACCEPT, REFUSE, EXPIRED
+    NONE, ACCEPT, REFUSE, EXPIRED, DELETED
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
@@ -4,6 +4,7 @@ import com.gdg.z_meet.domain.meeting.entity.Hi;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,8 +16,11 @@ public interface HiRepository extends JpaRepository<Hi,Long> {
     Hi findByFromAndTo(Team from, Team to);
     @Query("SELECT DISTINCT h FROM Hi h WHERE h.to.id IN (:teamIds) AND h.hiStatus='NONE' ORDER BY h.createdAt DESC")
     List<Hi> findRecevieHiList(@Param("teamIds") List<Long> teamIds);
-    @Query("SELECT DISTINCT h FROM Hi h WHERE h.from.id IN (:teamIds) ORDER BY h.createdAt DESC")
+    @Query("SELECT DISTINCT h FROM Hi h WHERE h.from.id IN (:teamIds) AND h.hiStatus!='DELETED' ORDER BY h.createdAt DESC")
     List<Hi> findSendHiList(@Param("teamIds") List<Long> teamIds);
+    @Modifying
+    @Query("UPDATE Hi h SET h.hiStatus = 'DELETED' WHERE h.from.id = :teamId OR h.to.id = :teamId")
+    void updateHiByTeamId(@Param("teamId") Long teamId);
 
     Boolean existsByFromAndTo(Team from, Team to);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
+import com.gdg.z_meet.domain.meeting.repository.HiRepository;
 import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
 import com.gdg.z_meet.domain.user.entity.User;
@@ -31,6 +32,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
     private final UserProfileRepository userProfileRepository;
     private final TeamRepository teamRepository;
     private final UserTeamRepository userTeamRepository;
+    private final HiRepository hiRepository;
 
     @Override
     @Transactional
@@ -101,10 +103,15 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
 
         userProfileRepository.subtractDelete(users);
         team.inactivateTeam();
+        delHi(teamId);
         teamRepository.save(team);
 
         if (teamRepository.existsByIdAndActiveStatus(teamId)) {
             throw new BusinessException(Code.TEAM_DELETE_FAILED);
         }
+    }
+
+    private void delHi(Long teamId){
+        hiRepository.updateHiByTeamId(teamId);
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- refacotr/#131-hi

## ⚡️ 작업동기

- 팀은 삭제할때 하이도 같이 삭제되도록 구현 
- 채팅 사용자 조회할 때 우리팀이 먼저 조회될때도 있고 나중에 조회될때도 있음 

## 🔑 주요 변경사항

- 하이 DELETED 상태 추가 및 팀 삭제시 하이도 삭제하도록 구현
- 채팅 사용자 조회할 때 우리팀이 먼저 조회되도록 설정
- 팀을 넘길때 이성팀/내팀이 아니라 이성/내로 넘기도록 수정 

## 💡 관련 이슈

- #131