### PR TITLE
[fix] 팀원 조회 로직 수정

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -29,13 +29,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
             "AND up.nickname LIKE :nickname% AND u.id != :userId " +
             "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
-            "WHERE ut.user = u AND t.teamType = :teamType)")
+            "WHERE ut.user = u AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE')")
     List<User> findAllByNicknameWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname, @Param("userId") Long userId, @Param("teamType") TeamType teamType);
 
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
             "AND u.phoneNumber LIKE :phoneNumber% AND u.id != :userId " +
             "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
-            "WHERE ut.user = u AND t.teamType = :teamType)")
+            "WHERE ut.user = u AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE')")
     List<User> findAllByPhoneNumberWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber, @Param("userId") Long userId, @Param("teamType") TeamType teamType);
 
     boolean existsByStudentNumber(String studentNumber);


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix/#154_search

## ⚡️ 작업동기

- 팀 삭제를 soft delete로 구현함에 따라 팀원 조회 로직 수정

## 🔑 주요 변경사항

- active인 팀이 존재하지 않는 유저 검색하도록 수정

## 💡 관련 이슈

- #154 