### PR TITLE
[FEAT] 하이, 티켓 개수 제한 설정

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
@@ -71,7 +71,7 @@ public class Team extends BaseEntity {
         this.activeStatus = ActiveStatus.INACTIVE;
     }
 
-    public void setNeulHi() { this.hi = 99; }
+    public void setInfiniteHi() { this.hi = 99; }
 
     public void patchVerification() { this.verification = Verification.COMPLETE; }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
@@ -80,8 +80,7 @@ public class HiQueryServiceImpl implements HiQueryService{
             throw new BusinessException(Code.HI_DUPLICATION);
         }
 
-        // 늘품제용 하이 무제한 설정
-        //from.decreaseHi(); // 하이 갯수 차감
+        from.decreaseHi(); // 하이 갯수 차감
 
         Hi hi = Hi.builder()
                 .hiStatus(HiStatus.NONE)

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -78,9 +78,6 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
                 .build();
         teamRepository.save(newTeam);
 
-        // 늘품제용 하이 무제한 설정
-        newTeam.setNeulHi();
-
         List<UserTeam> userTeams = teamMembers.stream()
                 .map(user -> MeetingConverter.toUserTeam(user, newTeam))
                 .collect(Collectors.toList());

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomCommandServiceImpl.java
@@ -42,7 +42,7 @@ public class RandomCommandServiceImpl implements RandomCommandService {
 
 
     @Override
-    @Transactional(readOnly = false)
+    @Transactional
     public void joinMatching(Long userId) {
 
         User user = userRepository.findByIdWithProfile(userId);
@@ -50,8 +50,7 @@ public class RandomCommandServiceImpl implements RandomCommandService {
             throw new BusinessException(Code.TICKET_LIMIT_EXCEEDED);
         }
 
-        // 늘품제용 티켓 무제한 설정
-        //user.getUserProfile().decreaseTicket(1);
+        user.getUserProfile().decreaseTicket(1);
 
         // 진행중인 매칭 확인
         if (matchingRepository.existsByWaitingMatching(userId)) {
@@ -90,7 +89,7 @@ public class RandomCommandServiceImpl implements RandomCommandService {
     }
 
     @Override
-    @Transactional(readOnly = false)
+    @Transactional
     public void cancelMatching(Long userId) {
 
         // 완료된 매칭은 취소 불가
@@ -99,10 +98,9 @@ public class RandomCommandServiceImpl implements RandomCommandService {
 
         userMatchingRepository.findByUserIdForUpdate(userId).ifPresent(this::safeDeleteUserMatching);
 
-        userRepository.findByIdWithProfile(userId);
+        User user = userRepository.findByIdWithProfile(userId);
 
-        // 늘품제용 티켓 무제한 설정
-        //user.getUserProfile().increaseTicket(1);
+        user.getUserProfile().increaseTicket(1);
 
         List<UserMatching> userMatchings = userMatchingRepository.findAllByMatchingIdWithUserProfile(matching.getId());
         messageMatching(matching, userMatchings);

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -92,5 +92,5 @@ public class UserProfile {
 
     public void upLevel() { this.level = Level.PLUS; }
 
-    public void setNeulTicket() { this.ticket = 99; }
+    public void setInfiniteTicket() { this.ticket = 99; }
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/service/UserService.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/service/UserService.java
@@ -81,9 +81,6 @@ public class UserService {
                 .build();
         userProfileRepository.save(userProfile);
 
-        // 늘품제용 티켓 무제한 설정
-        userProfile.setNeulTicket();
-
         return UserRes.SignUpRes.builder().message("회원가입 성공!").build();
     }
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#180_limit

## ⚡️ 작업동기

- 기존의 하이, 티켓 무제한 설정 제거하고 개수 제한 설정

## 🔑 주요 변경사항

- 회원가입 시 티켓 2개
- 팀 생성 시 하이 2개
- 미팅 참여 시 하이 차감
- 랜덤미팅 참여 시 티켓 차감

## 💡 관련 이슈

- #180 

<img width="460" alt="스크린샷 2025-04-23 오전 1 11 09" src="https://github.com/user-attachments/assets/9ccaaf61-445a-433c-ade5-1851c82a0ea2" />
<img width="460" alt="스크린샷 2025-04-23 오전 1 11 23" src="https://github.com/user-attachments/assets/bad5d4e6-ef86-437d-9e67-0eb2337b2c2f" />

