### PR TITLE
[FEAT, REFACTOR] 하이,채팅 1:1 추가 및 코드 리팩토링 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     image: mongo:latest
     container_name: mongodb1
     ports:
-      - "27017:27017"
+      - "27018:27017"
     networks:
       - gdg_network
     volumes:
@@ -49,7 +49,7 @@ services:
     container_name: nginx
     image: nginx:latest
     ports:
-      - "80:80"
+      - "90:80"
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/src/main/java/com/gdg/z_meet/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/controller/ChatRoomController.java
@@ -40,12 +40,12 @@ public class ChatRoomController {
         return Response.ok(chatRoomCommandService.addTeamJoinChat(hiDto));
     }
 
-//    @Operation(summary = "사용자 채팅방 추가", description = "관리자가 사용자를 채팅방에 추가합니다. 추가할 사용자 아이디들을 주세요")
-//    @PostMapping("/addUsers")
-//    public Response<ChatRoomDto.resultChatRoomDto> addUserToChatRoom(
-//            @RequestBody List<Long> userIds) {
-//        return Response.ok(chatRoomCommandService.addUserJoinChat(userIds));
-//    }
+    @Operation(summary = "(랜덤채팅 전용) 사용자 채팅방 추가", description = "관리자가 사용자를 채팅방에 추가합니다. 추가할 사용자 아이디들을 주세요")
+    @PostMapping("/addUsers")
+    public Response<ChatRoomDto.resultChatRoomDto> addUserToChatRoom(
+            @RequestBody List<Long> userIds) {
+        return Response.ok(chatRoomCommandService.addUserJoinChat(userIds));
+    }
 
     @Operation(summary = "사용자 채팅방 제거", description = "사용자를 지정된 채팅방에서 제거합니다. 채팅방 나가기와 동일한 기능 입니다. ")
     @DeleteMapping("/{roomId}/users")

--- a/src/main/java/com/gdg/z_meet/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/controller/ChatRoomController.java
@@ -36,14 +36,14 @@ public class ChatRoomController {
     @Operation(summary = "팀 채팅방 추가/하이 수락하기", description = "관리자가 팀을 채팅방에 추가합니다. 추가할 팀 아이디를 주세요")
     @PostMapping("/teams")
     public Response<ChatRoomDto.resultChatRoomDto> addTeamToChatRoom(
-            @RequestBody MeetingRequestDTO.hiDto hiDto) {
+            @RequestBody ChatRoomDto.hiDto hiDto) {
         return Response.ok(chatRoomCommandService.addTeamJoinChat(hiDto));
     }
 
     @Operation(summary = "사용자 채팅방 추가/하이 수락하기", description = "관리자가 사용자를 채팅방에 추가합니다. 추가할 사용자 아이디를 주세요")
     @PostMapping("/users")
     public Response<ChatRoomDto.resultChatRoomDto> addUserToChatRoom(
-            @RequestBody MeetingRequestDTO.hiDto hiDto) {
+            @RequestBody ChatRoomDto.hiDto hiDto) {
         return Response.ok(chatRoomCommandService.addUserJoinChat(hiDto));
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/controller/ChatRoomController.java
@@ -35,16 +35,23 @@ public class ChatRoomController {
 
     @Operation(summary = "팀 채팅방 추가/하이 수락하기", description = "관리자가 팀을 채팅방에 추가합니다. 추가할 팀 아이디를 주세요")
     @PostMapping("/teams")
-    public Response<ChatRoomDto.resultChatRoomDto> addUserToChatRoom(
+    public Response<ChatRoomDto.resultChatRoomDto> addTeamToChatRoom(
             @RequestBody MeetingRequestDTO.hiDto hiDto) {
         return Response.ok(chatRoomCommandService.addTeamJoinChat(hiDto));
+    }
+
+    @Operation(summary = "사용자 채팅방 추가/하이 수락하기", description = "관리자가 사용자를 채팅방에 추가합니다. 추가할 사용자 아이디를 주세요")
+    @PostMapping("/users")
+    public Response<ChatRoomDto.resultChatRoomDto> addUserToChatRoom(
+            @RequestBody MeetingRequestDTO.hiDto hiDto) {
+        return Response.ok(chatRoomCommandService.addUserJoinChat(hiDto));
     }
 
     @Operation(summary = "(랜덤채팅 전용) 사용자 채팅방 추가", description = "관리자가 사용자를 채팅방에 추가합니다. 추가할 사용자 아이디들을 주세요")
     @PostMapping("/addUsers")
     public Response<ChatRoomDto.resultChatRoomDto> addUserToChatRoom(
             @RequestBody List<Long> userIds) {
-        return Response.ok(chatRoomCommandService.addUserJoinChat(userIds));
+        return Response.ok(chatRoomCommandService.addRandomUserJoinChat(userIds));
     }
 
     @Operation(summary = "사용자 채팅방 제거", description = "사용자를 지정된 채팅방에서 제거합니다. 채팅방 나가기와 동일한 기능 입니다. ")

--- a/src/main/java/com/gdg/z_meet/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/dto/ChatRoomDto.java
@@ -15,6 +15,16 @@ public class ChatRoomDto {
         private Long chatRoomid;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class hiDto {
+        Long toId;
+        Long fromId;
+    }
+
+
     @Getter
     @AllArgsConstructor
     @Builder

--- a/src/main/java/com/gdg/z_meet/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/entity/ChatRoom.java
@@ -18,7 +18,7 @@ public class ChatRoom extends BaseEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    private ChatType chatType;  // TEAM or RANDOM
+    private ChatType chatType;
 
     @Column(unique = true)
     private Long randomChatId;

--- a/src/main/java/com/gdg/z_meet/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/entity/ChatRoom.java
@@ -20,5 +20,6 @@ public class ChatRoom extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ChatType chatType;  // TEAM or RANDOM
 
+    @Column(unique = true)
     private Long randomChatId;
 }

--- a/src/main/java/com/gdg/z_meet/domain/chat/entity/status/ChatType.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/entity/status/ChatType.java
@@ -1,5 +1,5 @@
 package com.gdg.z_meet.domain.chat.entity.status;
 
 public enum ChatType {
-    TEAM,RANDOM
+    TEAM,RANDOM, USER
 }

--- a/src/main/java/com/gdg/z_meet/domain/chat/repository/JoinChatRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/repository/JoinChatRepository.java
@@ -27,4 +27,9 @@ public interface JoinChatRepository extends JpaRepository<JoinChat, Long> {
     @Modifying
     @Query("UPDATE JoinChat j SET j.status = 'INACTIVE' WHERE j.user.id = :userId")
     void deleteJoinChatWithUser(@Param("userId") Long userId);
+
+    @Query("SELECT jc FROM JoinChat jc WHERE jc.chatRoom.id = :chatRoomId AND jc.user.id != :userId")
+    Optional<JoinChat> findUserByChatRoomIdAndUserNotUserId(@Param("chatRoomId") Long chatRoomId, @Param("userId") Long userId);
+
+
 }

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
@@ -121,7 +121,7 @@ public class ChatRoomCommandService {
     }
 
     public ChatRoomDto.resultChatRoomDto addUserJoinChat(List<Long> userIds){
-        if(userIds.size() != 6)
+        if(userIds.size() != 4)
             throw new BusinessException(Code.RANDOM_MEETING_USER_COUNT);
 
         // 가장 큰 randomChatId 조회 후 +1

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
@@ -52,7 +52,7 @@ public class ChatRoomCommandService {
     private static final String CHAT_ROOMS_KEY = "chatrooms";
     private static final String CHAT_ROOM_ACTIVITY_KEY = "chatroom:activity";
 
-    //레디스 초기화
+    //레디스 초기화 : 랜덤채팅 최신id 저장
     @PostConstruct
     public void initRandomChatIdRedis() {
         String key = "chat:randomChatId";

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
@@ -121,7 +121,7 @@ public class ChatRoomCommandService {
         Team from = teams.get("from");
         Team to = teams.get("to");
 
-        Hi hi = hiRepository.findByFromIdAndToId(from.getId(), to.getId());
+        Hi hi = hiRepository.findByFromIdAndToIdAndHiStatus(from.getId(), to.getId(), HiStatus.NONE);
         if (hi == null) throw new BusinessException(Code.HI_NOT_FOUND);
         hi.changeStatus(HiStatus.ACCEPT);
         hiRepository.save(hi);
@@ -154,7 +154,8 @@ public class ChatRoomCommandService {
         User from = users.get("from");
         User to = users.get("to");
 
-        Hi hi = hiRepository.findByFromIdAndToId(from.getId(), to.getId());
+        Hi hi = hiRepository.findByFromIdAndToIdAndHiStatus(from.getId(), to.getId(), HiStatus.NONE);
+        System.out.println("하이에용 : " + hi.toString());
         if (hi == null) throw new BusinessException(Code.HI_NOT_FOUND);
         hi.changeStatus(HiStatus.ACCEPT);
         hiRepository.save(hi);

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
@@ -17,6 +17,7 @@ import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
 import com.gdg.z_meet.domain.meeting.repository.HiRepository;
+import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
 import com.gdg.z_meet.domain.meeting.service.HiCommandService;
 import com.gdg.z_meet.domain.meeting.service.HiCommandServiceImpl;
@@ -53,6 +54,7 @@ public class ChatRoomCommandService {
     private static final String CHAT_ROOMS_KEY = "chatrooms";
     private static final String CHAT_ROOM_ACTIVITY_KEY = "chatroom:activity";
     private final HiCommandServiceImpl hiCommandService;
+    private final TeamRepository teamRepository;
 
     //레디스 초기화 : 랜덤채팅 최신id 저장
     @PostConstruct
@@ -110,7 +112,12 @@ public class ChatRoomCommandService {
         List<Long> teamIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
 
         // 공통 메서드 호출하여 from, to 팀 할당
-        Map<String, Team> teams = hiCommandService.assignTeams(teamIds, hiDto.getFromId());
+        Map<String, Team> teams = hiCommandService.assignEntities(
+                teamRepository.findByIdIn(teamIds),
+                hiDto.getFromId(),
+                Team::getId
+        );
+
         Team from = teams.get("from");
         Team to = teams.get("to");
 

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
@@ -108,7 +108,7 @@ public class ChatRoomCommandService {
 
     // 팀으로 채팅방 추가
     @Transactional
-    public ChatRoomDto.resultChatRoomDto addTeamJoinChat(MeetingRequestDTO.hiDto hiDto) {
+    public ChatRoomDto.resultChatRoomDto addTeamJoinChat(ChatRoomDto.hiDto hiDto) {
         List<Long> teamIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
 
         // 공통 메서드 호출하여 from, to 팀 할당
@@ -142,7 +142,7 @@ public class ChatRoomCommandService {
 
     // 사용자 채팅방 추가
     @Transactional
-    public ChatRoomDto.resultChatRoomDto addUserJoinChat(MeetingRequestDTO.hiDto hiDto) {
+    public ChatRoomDto.resultChatRoomDto addUserJoinChat(ChatRoomDto.hiDto hiDto) {
         List<Long> userIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
 
         // 공통 메서드 호출하여 from, to 팀 할당

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
@@ -18,6 +18,8 @@ import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
 import com.gdg.z_meet.domain.meeting.repository.HiRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
+import com.gdg.z_meet.domain.meeting.service.HiCommandService;
+import com.gdg.z_meet.domain.meeting.service.HiCommandServiceImpl;
 import com.gdg.z_meet.domain.meeting.service.HiQueryServiceImpl;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.repository.UserRepository;
@@ -45,12 +47,12 @@ public class ChatRoomCommandService {
     private final UserRepository userRepository;
     private final UserTeamRepository userTeamRepository;
     private final TeamChatRoomRepository teamChatRoomRepository;
-    private final HiQueryServiceImpl hiQueryService;
     private final HiRepository hiRepository;
     private final ChatRoomQueryService chatRoomQueryService;
 
     private static final String CHAT_ROOMS_KEY = "chatrooms";
     private static final String CHAT_ROOM_ACTIVITY_KEY = "chatroom:activity";
+    private final HiCommandServiceImpl hiCommandService;
 
     //레디스 초기화 : 랜덤채팅 최신id 저장
     @PostConstruct
@@ -108,11 +110,11 @@ public class ChatRoomCommandService {
         List<Long> teamIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
 
         // 공통 메서드 호출하여 from, to 팀 할당
-        Map<String, Team> teams = hiQueryService.assignTeams(teamIds, hiDto.getFromId());
+        Map<String, Team> teams = hiCommandService.assignTeams(teamIds, hiDto.getFromId());
         Team from = teams.get("from");
         Team to = teams.get("to");
 
-        Hi hi = hiRepository.findByFromAndTo(from, to);
+        Hi hi = hiRepository.findByFromIdAndToId(from.getId(), to.getId());
         if (hi == null) throw new BusinessException(Code.HI_NOT_FOUND);
         hi.changeStatus(HiStatus.ACCEPT);
         hiRepository.save(hi);

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
@@ -136,6 +136,13 @@ public class ChatRoomQueryService {
             return "랜덤채팅 " + (chatRoom.getRandomChatId() +30) + "번방";
         }
 
+        if (chatRoom.getChatType() == ChatType.USER) {//사용자 채팅방일 경우 상대방 이름 반환
+            JoinChat joinChat = joinChatRepository.findUserByChatRoomIdAndUserNotUserId(chatRoomId, userId)
+                                                    .orElseThrow(() -> new BusinessException(Code.JOINCHAT_NOT_FOUND));
+            User user = joinChat.getUser();
+            return user.getName();
+        }
+
         // 해당 채팅방의 팀 조회
         List<TeamChatRoom> teamChatRooms = teamChatRoomRepository.findByChatRoomId(chatRoomId);
 

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomQueryService.java
@@ -140,7 +140,7 @@ public class ChatRoomQueryService {
             JoinChat joinChat = joinChatRepository.findUserByChatRoomIdAndUserNotUserId(chatRoomId, userId)
                                                     .orElseThrow(() -> new BusinessException(Code.JOINCHAT_NOT_FOUND));
             User user = joinChat.getUser();
-            return user.getName();
+            return user.getUserProfile().getNickname();
         }
 
         // 해당 채팅방의 팀 조회
@@ -205,12 +205,12 @@ public class ChatRoomQueryService {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(Code.CHATROOM_NOT_FOUND));
 
-        // 채팅방이 RANDOM 타입인 경우 성별로 사용자 구분
-        if (chatRoom.getChatType() == ChatType.RANDOM) {
-            return getRandomChatRoomUserList(userId, roomId);
+        // 채팅방이 TEAM 타입인 경우 팀으로 사용자 구분
+        if (chatRoom.getChatType() == ChatType.TEAM) {
+            return getTeamChatRoomUserList(userId, roomId);
         }
+        return getRandomChatRoomUserList(userId, roomId);
 
-        return getTeamChatRoomUserList(userId, roomId);
 
 
     }

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/MessageCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/MessageCommandService.java
@@ -108,8 +108,10 @@ public class MessageCommandService {
 
             mongoMessageRepository.saveAll(messageList);
 
-            // Redis에서 모든 메시지 제거
-            redisTemplate.delete(chatRoomMessagesKey);
+             //레디스에서 최신 nn개의 메시지를 제외하고 모두 저장
+            if (totalMessages > MAX_REDIS_MESSAGES) {
+                redisTemplate.opsForList().trim(chatRoomMessagesKey, -MAX_REDIS_MESSAGES, -1);
+            }
         }
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/MessageCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/MessageCommandService.java
@@ -74,49 +74,45 @@ public class MessageCommandService {
     public void saveMessagesToDB() {
 
         List<ChatRoom> chatRooms = chatRoomRepository.findAll();  // MySQL에서 chatRoom 조회
+
         for (ChatRoom chatRoom : chatRooms) {
             Long chatRoomId = chatRoom.getId();
             String chatRoomMessagesKey = String.format(CHAT_ROOM_MESSAGES_KEY, chatRoomId);
+
             Long totalMessages = redisTemplate.opsForList().size(chatRoomMessagesKey);
+            if (totalMessages == null || totalMessages == 0) continue; // 저장할 메시지가 없음
 
-            if (totalMessages == null || totalMessages <= MAX_REDIS_MESSAGES) {
-                continue;  // MAX개 이하라면 저장하지 않음
-            }
+            List<Object> messages = redisTemplate.opsForList().range(chatRoomMessagesKey, 0, -1);
+            if (messages == null || messages.isEmpty()) continue;
 
-            int messagesToMove = (int) (totalMessages - MAX_REDIS_MESSAGES);
-            if (messagesToMove <= 0) continue;  // 저장할 메시지가 없음
+            List<ChatMessage> chatMessages = messages.stream()
+                    .map(obj -> objectMapper.convertValue(obj, ChatMessage.class))
+                    .filter(chatMessage -> chatMessage.getSenderId() != null)
+                    .collect(Collectors.toList());
 
-            List<Object> messages = redisTemplate.opsForList().range(chatRoomMessagesKey, 0, messagesToMove - 1);
-            if (messages != null && !messages.isEmpty()) {
-                List<ChatMessage> chatMessages = messages.stream()
-                        .map(obj -> objectMapper.convertValue(obj, ChatMessage.class))
-                        .filter(chatMessage -> chatMessage.getSenderId() != null)
-                        .collect(Collectors.toList());
+            List<Message> messageList = chatMessages.stream()
+                    .map(chatMessage -> {
+                        User user = userRepository.findById(chatMessage.getSenderId())
+                                .orElseThrow(() -> new BusinessException(Code.MEMBER_NOT_FOUND));
+                        LocalDateTime now = LocalDateTime.now();
 
-                List<Message> messageList = chatMessages.stream()
-                        .map(chatMessage -> {
-                            // MySQL에서 userId, chatRoomId를 가져와 MongoDB에 저장
-                            User user = userRepository.findById(chatMessage.getSenderId())
-                                    .orElseThrow(() -> new BusinessException(Code.MEMBER_NOT_FOUND));
-                            LocalDateTime now = LocalDateTime.now();
+                        return Message.builder()
+                                .chatRoomId(chatRoomId.toString())
+                                .userId(user.getId().toString())
+                                .content(chatMessage.getContent())
+                                .createdAt(chatMessage.getSendAt())
+                                .updatedAt(now)
+                                .build();
+                    })
+                    .collect(Collectors.toList());
 
-                            return Message.builder()
-                                    .chatRoomId(chatRoom.getId().toString())
-                                    .userId(user.getId().toString())
-                                    .content(chatMessage.getContent())
-                                    .createdAt(chatMessage.getSendAt())
-                                    .updatedAt(now)
-                                    .build();
-                        })
-                        .collect(Collectors.toList());
-                mongoMessageRepository.saveAll(messageList);
+            mongoMessageRepository.saveAll(messageList);
 
-                // 저장한 메시지를 Redis에서 삭제
-                redisTemplate.opsForList().trim(chatRoomMessagesKey, messagesToMove, -1);
-            }
+            // Redis에서 모든 메시지 제거
+            redisTemplate.delete(chatRoomMessagesKey);
         }
-
     }
+
 
 
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -3,6 +3,7 @@ package com.gdg.z_meet.domain.meeting.controller;
 import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
+import com.gdg.z_meet.domain.meeting.service.HiCommandService;
 import com.gdg.z_meet.domain.meeting.service.HiQueryService;
 import com.gdg.z_meet.domain.meeting.service.MeetingCommandService;
 import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
@@ -28,6 +29,7 @@ public class MeetingController {
     private final MeetingQueryService meetingQueryService;
     private final MeetingCommandService meetingCommandService;
     private final HiQueryService hiQueryService;
+    private final HiCommandService hiCommandService;
 
     @Operation(summary = "팀 갤러리 조회", description = "12팀씩 페이징 됩니다.")
     @GetMapping
@@ -102,14 +104,14 @@ public class MeetingController {
     @Operation(summary = "하이 보내기")
     @PostMapping("/hi/send")
     public Response<String> sendHi(@RequestBody MeetingRequestDTO.hiDto hiDto){
-        hiQueryService.sendHi(hiDto);
+        hiCommandService.sendHi(hiDto);
         return Response.ok(hiDto.getToId() +"팀에게 하이가 보내졌습니다. ");
     }
 
     @Operation(summary = "하이 거절하기")
     @PatchMapping("/hi/refuse")
     public Response<String> refuseHi(@RequestBody MeetingRequestDTO.hiDto hiDto){
-        hiQueryService.refuseHi(hiDto);
+        hiCommandService.refuseHi(hiDto);
         return Response.ok(hiDto.getFromId() +"팀이 보낸 하이가 거절되었습니다. ");
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
@@ -1,5 +1,6 @@
 package com.gdg.z_meet.domain.meeting.dto;
 
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -21,6 +22,7 @@ public class MeetingRequestDTO {
     public static class hiDto {
         Long toId;
         Long fromId;
+        HiType type; //USER or TEAM
     }
 
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -1,5 +1,6 @@
 package com.gdg.z_meet.domain.meeting.dto;
 
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
 import com.gdg.z_meet.domain.user.entity.enums.Major;
 import com.gdg.z_meet.domain.user.entity.enums.Music;
 import lombok.AllArgsConstructor;
@@ -117,6 +118,7 @@ public class MeetingResponseDTO {
         List<UserProfileDto> userProfileDtos;
         Double age;
         String dateTime;
+        HiType type; //USER or TEAM
 
         @Getter
         @AllArgsConstructor

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Hi.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Hi.java
@@ -1,6 +1,7 @@
 package com.gdg.z_meet.domain.meeting.entity;
 
 import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
 import com.gdg.z_meet.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -21,13 +22,15 @@ public class Hi extends BaseEntity {
     @Column(nullable = false)
     private HiStatus hiStatus;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "from_id")
-    private Team from;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private HiType hiType;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "to_id")
-    private Team to;
+    @Column(name = "from_id")
+    private Long fromId;
+
+    @Column(name = "to_id")
+    private Long toId;
 
     // hi Status 변경
     public void changeStatus(HiStatus hiStatus) {

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/enums/HiType.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/enums/HiType.java
@@ -1,0 +1,6 @@
+package com.gdg.z_meet.domain.meeting.entity.enums;
+
+public enum HiType {
+    USER,
+    TEAM
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface HiRepository extends JpaRepository<Hi,Long> {
@@ -22,6 +23,8 @@ public interface HiRepository extends JpaRepository<Hi,Long> {
     @Modifying
     @Query("UPDATE Hi h SET h.hiStatus = 'DELETED' WHERE h.fromId = :teamId OR h.toId = :teamId")
     void updateHiByTeamId(@Param("teamId") Long teamId);
+
+    Optional<Hi> findByFromIdAndToIdAndHiType(Long fromId, Long toId, HiType hiType);
 
     Boolean existsByFromIdAndToIdAndHiType(Long fromId, Long toId, HiType hiType);
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 public interface HiRepository extends JpaRepository<Hi,Long> {
     Boolean existsByFromIdAndToIdAndHiStatusNotAndHiType(Long from, Long to, HiStatus status, HiType hiType);
-    Hi findByFromIdAndToId(Long from, Long to);
+    Hi findByFromIdAndToIdAndHiStatus(Long from, Long to, HiStatus status);
     @Query("SELECT DISTINCT h FROM Hi h WHERE h.toId IN (:teamIds) AND h.hiStatus='NONE' ORDER BY h.createdAt DESC")
     List<Hi> findRecevieHiList(@Param("teamIds") List<Long> teamIds);
     @Query("SELECT DISTINCT h FROM Hi h WHERE h.fromId IN (:teamIds) AND h.hiStatus!='DELETED' ORDER BY h.createdAt DESC")

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
@@ -3,6 +3,7 @@ package com.gdg.z_meet.domain.meeting.repository;
 import com.gdg.z_meet.domain.meeting.entity.Hi;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,15 +13,16 @@ import java.util.List;
 
 
 public interface HiRepository extends JpaRepository<Hi,Long> {
-    Boolean existsByFromAndToAndHiStatusNot(Team from, Team to, HiStatus status);
-    Hi findByFromAndTo(Team from, Team to);
-    @Query("SELECT DISTINCT h FROM Hi h WHERE h.to.id IN (:teamIds) AND h.hiStatus='NONE' ORDER BY h.createdAt DESC")
+    Boolean existsByFromIdAndToIdAndHiStatusNotAndHiType(Long from, Long to, HiStatus status, HiType hiType);
+    Hi findByFromIdAndToId(Long from, Long to);
+    @Query("SELECT DISTINCT h FROM Hi h WHERE h.toId IN (:teamIds) AND h.hiStatus='NONE' ORDER BY h.createdAt DESC")
     List<Hi> findRecevieHiList(@Param("teamIds") List<Long> teamIds);
-    @Query("SELECT DISTINCT h FROM Hi h WHERE h.from.id IN (:teamIds) AND h.hiStatus!='DELETED' ORDER BY h.createdAt DESC")
+    @Query("SELECT DISTINCT h FROM Hi h WHERE h.fromId IN (:teamIds) AND h.hiStatus!='DELETED' ORDER BY h.createdAt DESC")
     List<Hi> findSendHiList(@Param("teamIds") List<Long> teamIds);
     @Modifying
-    @Query("UPDATE Hi h SET h.hiStatus = 'DELETED' WHERE h.from.id = :teamId OR h.to.id = :teamId")
+    @Query("UPDATE Hi h SET h.hiStatus = 'DELETED' WHERE h.fromId = :teamId OR h.toId = :teamId")
     void updateHiByTeamId(@Param("teamId") Long teamId);
 
-    Boolean existsByFromAndTo(Team from, Team to);
+    Boolean existsByFromIdAndToIdAndHiType(Long fromId, Long toId, HiType hiType);
+
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandService.java
@@ -1,0 +1,10 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
+
+public interface HiCommandService {
+    void sendHi(MeetingRequestDTO.hiDto hiDto);
+    void sendUserHi(MeetingRequestDTO.hiDto hiDto);
+    void sendTeamHi(MeetingRequestDTO.hiDto hiDto);
+    void refuseHi(MeetingRequestDTO.hiDto hiDto);
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandServiceImpl.java
@@ -29,9 +29,6 @@ public class HiCommandServiceImpl implements HiCommandService {
 
     private final HiRepository hiRepository;
     private final TeamRepository teamRepository;
-    private final MeetingQueryServiceImpl meetingQueryService;
-    private final UserTeamRepository userTeamRepository;
-    private final UserProfileRepository userProfileRepository;
     private final UserRepository userRepository;
 
     // 중복 제거용 유틸 메서드 - Team/User 공통 처리
@@ -87,9 +84,7 @@ public class HiCommandServiceImpl implements HiCommandService {
         // 유효성 검사
         if (from.getTeamType() != to.getTeamType()) throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
         if (from.getGender() == to.getGender()) throw new BusinessException(Code.SAME_GENDER);
-        if (hiRepository.existsByFromIdAndToIdAndHiStatusNotAndHiType(from.getId(), to.getId(), HiStatus.EXPIRED, HiType.TEAM)) {
-            throw new BusinessException(Code.HI_DUPLICATION);
-        }
+        validateHiDuplication(from.getId(), to.getId(), HiType.TEAM);
 
         // 늘품제용 하이 무제한 설정
         //from.decreaseHi(); // 하이 갯수 차감
@@ -120,9 +115,7 @@ public class HiCommandServiceImpl implements HiCommandService {
 
         // 유효성 검사
         if (from.getUserProfile().getGender() == to.getUserProfile().getGender()) throw new BusinessException(Code.SAME_GENDER);
-        if (hiRepository.existsByFromIdAndToIdAndHiStatusNotAndHiType(from.getId(), to.getId(), HiStatus.EXPIRED, HiType.USER)) {
-            throw new BusinessException(Code.HI_DUPLICATION);
-        }
+        validateHiDuplication(from.getId(), to.getId(), HiType.USER);
 
         // 늘품제용 하이 무제한 설정
         //from.decreaseHi(); // 하이 갯수 차감

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandServiceImpl.java
@@ -1,0 +1,169 @@
+package com.gdg.z_meet.domain.meeting.service;
+
+import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
+import com.gdg.z_meet.domain.meeting.entity.Hi;
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
+import com.gdg.z_meet.domain.meeting.repository.HiRepository;
+import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
+import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.repository.UserProfileRepository;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import com.gdg.z_meet.global.exception.BusinessException;
+import com.gdg.z_meet.global.response.Code;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@AllArgsConstructor
+public class HiCommandServiceImpl implements HiCommandService {
+
+    private final HiRepository hiRepository;
+    private final TeamRepository teamRepository;
+    private final MeetingQueryServiceImpl meetingQueryService;
+    private final UserTeamRepository userTeamRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final UserRepository userRepository;
+
+    // 팀 분리
+    public Map<String, Team> assignTeams(List<Long> teamIds, Long fromId) {
+        List<Team> teams = teamRepository.findByIdIn(teamIds);
+
+        if (teams.size() != 2) {
+            throw new BusinessException(Code.TEAM_NOT_FOUND); // 모든 팀을 못 찾은 경우
+        }
+
+        Team from = null;
+        Team to = null;
+
+        // 팀 순서 확인 후 할당
+        if (teams.get(0).getId().equals(fromId)) {
+            from = teams.get(0); // 보내는 팀
+            to = teams.get(1);   // 받는 팀
+        } else {
+            from = teams.get(1);
+            to = teams.get(0);
+        }
+
+        Map<String, Team> teamMap = new HashMap<>();
+        teamMap.put("from", from);
+        teamMap.put("to", to);
+        return teamMap;
+    }
+
+    // 유저 분리
+    public Map<String, User> assignUsers(List<Long> userIds, Long fromId) {
+        List<User> users = userRepository.findByIdIn(userIds);
+
+        if (users.size() != 2) {
+            throw new BusinessException(Code.USER_NOT_FOUND); // 모든 팀을 못 찾은 경우
+        }
+
+        User from = null;
+        User to = null;
+
+        // 팀 순서 확인 후 할당
+        if (users.get(0).getId().equals(fromId)) {
+            from = users.get(0); // 보낸 유저
+            to = users.get(1);   // 받은 유저
+        } else {
+            from = users.get(1);
+            to = users.get(0);
+        }
+
+        Map<String, User> userMap = new HashMap<>();
+        userMap.put("from", from);
+        userMap.put("to", to);
+        return userMap;
+    }
+
+    @Override
+    public void sendHi(MeetingRequestDTO.hiDto hiDto) {
+        if(hiDto.getType()== HiType.USER){
+            sendUserHi(hiDto);
+        }
+        else sendTeamHi(hiDto);
+    }
+
+
+    @Override
+    @Transactional
+    public void sendTeamHi(MeetingRequestDTO.hiDto hiDto) {
+        List<Long> teamIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
+
+        // 공통 메서드 호출하여 from, to 팀 할당
+        Map<String, Team> teams = assignTeams(teamIds, hiDto.getFromId());
+        Team from = teams.get("from");
+        Team to = teams.get("to");
+
+        // 유효성 검사
+        if (from.getTeamType() != to.getTeamType()) throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
+        if (from.getGender() == to.getGender()) throw new BusinessException(Code.SAME_GENDER);
+        if (hiRepository.existsByFromIdAndToIdAndHiStatusNotAndHiType(from.getId(), to.getId(), HiStatus.EXPIRED, HiType.TEAM)) {
+            throw new BusinessException(Code.HI_DUPLICATION);
+        }
+
+        // 늘품제용 하이 무제한 설정
+        //from.decreaseHi(); // 하이 갯수 차감
+
+        Hi hi = Hi.builder()
+                .hiStatus(HiStatus.NONE)
+                .fromId(from.getId())
+                .toId(to.getId())
+                .hiType(HiType.TEAM)
+                .build();
+        hiRepository.save(hi);
+    }
+
+    @Override
+    @Transactional
+    public void sendUserHi(MeetingRequestDTO.hiDto hiDto) {
+        List<Long> userIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
+
+        // 공통 메서드 호출하여 from, to 팀 할당
+        Map<String, User> users = assignUsers(userIds, hiDto.getFromId());
+        User from = users.get("from");
+        User to = users.get("to");
+
+        // 유효성 검사
+        if (from.getUserProfile().getGender() == to.getUserProfile().getGender()) throw new BusinessException(Code.SAME_GENDER);
+        if (hiRepository.existsByFromIdAndToIdAndHiStatusNotAndHiType(from.getId(), to.getId(), HiStatus.EXPIRED, HiType.USER)) {
+            throw new BusinessException(Code.HI_DUPLICATION);
+        }
+
+        // 늘품제용 하이 무제한 설정
+        //from.decreaseHi(); // 하이 갯수 차감
+
+        Hi hi = Hi.builder()
+                .hiStatus(HiStatus.NONE)
+                .fromId(from.getId())
+                .toId(to.getId())
+                .hiType(HiType.USER)
+                .build();
+        hiRepository.save(hi);
+    }
+
+    @Override
+    @Transactional
+    public void refuseHi(MeetingRequestDTO.hiDto hiDto) {
+        List<Long> teamIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
+
+        // 공통 메서드 호출하여 from, to 팀 할당
+        Map<String, Team> teams = assignTeams(teamIds, hiDto.getFromId());
+        Team from = teams.get("from");
+        Team to = teams.get("to");
+
+        Hi hi = hiRepository.findByFromIdAndToId(from.getId(), to.getId());
+        if (hi == null) throw new BusinessException(Code.HI_NOT_FOUND);
+        hi.changeStatus(HiStatus.REFUSE);
+        hiRepository.save(hi);
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryService.java
@@ -6,8 +6,5 @@ import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import java.util.List;
 
 public interface HiQueryService  {
-        void sendHi(MeetingRequestDTO.hiDto hiDto);
-        void refuseHi(MeetingRequestDTO.hiDto hiDto);
         List<MeetingResponseDTO.hiListDto> checkHiList(Long teamId, String action);
-
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
@@ -7,6 +7,7 @@ import com.gdg.z_meet.domain.meeting.entity.Hi;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
 import com.gdg.z_meet.domain.meeting.repository.HiRepository;
 import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
@@ -32,120 +33,60 @@ public class HiQueryServiceImpl implements HiQueryService{
 
     private final HiRepository hiRepository;
     private final TeamRepository teamRepository;
-    private final MeetingQueryServiceImpl meetingQueryService;
     private final UserTeamRepository userTeamRepository;
     private final UserProfileRepository userProfileRepository;
     private final UserRepository userRepository;
 
-    // 공통 메서드로 분리
-    public Map<String, Team> assignTeams(List<Long> teamIds, Long fromId) {
-        List<Team> teams = teamRepository.findByIdIn(teamIds);
-
-        if (teams.size() != 2) {
-            throw new BusinessException(Code.TEAM_NOT_FOUND); // 모든 팀을 못 찾은 경우
-        }
-
-        Team from = null;
-        Team to = null;
-
-        // 팀 순서 확인 후 할당
-        if (teams.get(0).getId().equals(fromId)) {
-            from = teams.get(0); // 보내는 팀
-            to = teams.get(1);   // 받는 팀
-        } else {
-            from = teams.get(1); // 보내는 팀
-            to = teams.get(0);   // 받는 팀
-        }
-
-        Map<String, Team> teamMap = new HashMap<>();
-        teamMap.put("from", from);
-        teamMap.put("to", to);
-        return teamMap;
-    }
-
-    @Override
-    @Transactional
-    public void sendHi(MeetingRequestDTO.hiDto hiDto) {
-        List<Long> teamIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
-
-        // 공통 메서드 호출하여 from, to 팀 할당
-        Map<String, Team> teams = assignTeams(teamIds, hiDto.getFromId());
-        Team from = teams.get("from");
-        Team to = teams.get("to");
-
-        // 유효성 검사
-        if (from.getTeamType() != to.getTeamType()) throw new BusinessException(Code.TEAM_TYPE_MISMATCH);
-        if (from.getGender() == to.getGender()) throw new BusinessException(Code.SAME_GENDER);
-        if (hiRepository.existsByFromAndToAndHiStatusNot(from, to, HiStatus.EXPIRED)) {
-            throw new BusinessException(Code.HI_DUPLICATION);
-        }
-
-        // 늘품제용 하이 무제한 설정
-        //from.decreaseHi(); // 하이 갯수 차감
-
-        Hi hi = Hi.builder()
-                .hiStatus(HiStatus.NONE)
-                .from(from)
-                .to(to)
-                .build();
-        hiRepository.save(hi);
-    }
-
-    @Override
-    @Transactional
-    public void refuseHi(MeetingRequestDTO.hiDto hiDto) {
-        List<Long> teamIds = Arrays.asList(hiDto.getFromId(), hiDto.getToId());
-
-        // 공통 메서드 호출하여 from, to 팀 할당
-        Map<String, Team> teams = assignTeams(teamIds, hiDto.getFromId());
-        Team from = teams.get("from");
-        Team to = teams.get("to");
-
-        Hi hi = hiRepository.findByFromAndTo(from, to);
-        if (hi == null) throw new BusinessException(Code.HI_NOT_FOUND);
-        hi.changeStatus(HiStatus.REFUSE);
-        hiRepository.save(hi);
-    }
 
     @Override
     @Transactional
     public List<MeetingResponseDTO.hiListDto> checkHiList(Long userId, String action){
         List<UserTeam> myTeams = userTeamRepository.findByUserId(userId);
-        if(myTeams.size()==0) throw new BusinessException(Code.TEAM_NOT_FOUND);
+        //if(myTeams.size()==0) throw new BusinessException(Code.TEAM_NOT_FOUND);
         List<Long> myTeamIds = myTeams.stream()
                 .map(userTeam -> userTeam.getTeam().getId()) // UserTeam에서 teamId 추출
                 .collect(Collectors.toList());
 
+        //myTeamIds에 userId추가
+        myTeamIds.add(userId);
+
         List<Hi> hiList;
-        List<Long> teamIds;
         if(action.equals("Receive")) {
             hiList = hiRepository.findRecevieHiList(myTeamIds);
-            teamIds = hiList.stream()
-                    .map(hi -> hi.getFrom().getId()) // 보낸 팀의 id
-                    .collect(Collectors.toSet()) // 중복 제거
-                    .stream().toList();
         }
         else{
             hiList = hiRepository.findSendHiList(myTeamIds);
-            teamIds = hiList.stream()
-                    .map(hi -> hi.getTo().getId())
-                    .collect(Collectors.toSet())
-                    .stream().toList();
         }
-
-        List<Team> teamList = teamRepository.findByIdIn(teamIds);
 
         // 여러 개의 hiListDto 생성
         List<MeetingResponseDTO.hiListDto> hiListDtos = new ArrayList<>();
         for (Hi hi : hiList) {
             if(hi.getHiStatus()!=HiStatus.NONE && action.equals("Receive")) continue;
 
-            Team team = action.equals("Receive") ? hi.getFrom() : hi.getTo();
-            Team myteam = action.equals("Receive") ? hi.getTo() : hi.getFrom();
+            Long teamId = action.equals("Receive") ? hi.getFromId() : hi.getToId();
+            Long myteamId = action.equals("Receive") ? hi.getToId() : hi.getFromId();
+            String otherName;
 
-            // 각 팀에 대해 UserProfileDto 만들기
-            List<UserProfile> userProfiles = userProfileRepository.findByTeamId(team.getId());
+            if(hi.getHiType()== HiType.USER) {
+                User otherUser = userRepository.findById(teamId).orElseThrow(() -> new BusinessException(Code.USER_NOT_FOUND));
+                otherName = otherUser.getName();
+            }
+            else{
+                Team team = teamRepository.findById(teamId).orElseThrow(() -> new BusinessException(Code.TEAM_NOT_FOUND));
+                otherName = team.getName();
+            }
 
+            List<UserProfile> userProfiles;
+
+            if(hi.getHiType()== HiType.USER) {
+                UserProfile profile = userProfileRepository.findByUserId(userId)
+                        .orElseThrow(() -> new BusinessException(Code.USER_PROFILE_NOT_FOUND));
+                userProfiles = List.of(profile);
+            }
+            else {
+                // 각 팀에 대해 UserProfileDto 만들기
+                userProfiles = userProfileRepository.findByTeamId(teamId);
+            }
             // UserProfileDto 리스트 생성
             List<MeetingResponseDTO.hiListDto.UserProfileDto> userProfileDtos = new ArrayList<>();
             int sum = 0;
@@ -160,7 +101,6 @@ public class HiQueryServiceImpl implements HiQueryService{
             }
 
             double averageAge = userProfiles.isEmpty() ? 0 : Math.round((sum / (double) userProfiles.size()) * 10.0) / 10.0;
-
 
             LocalDateTime sentTime = hi.getCreatedAt(); // Hi 생성 시간
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM-dd HH:mm");
@@ -193,9 +133,10 @@ public class HiQueryServiceImpl implements HiQueryService{
 
             // 하나의 hiListDto 생성
             MeetingResponseDTO.hiListDto hiDto = MeetingResponseDTO.hiListDto.builder()
-                    .myTeamId(myteam.getId())
-                    .teamId(team.getId())
-                    .teamName(team.getName())
+                    .myTeamId(myteamId)
+                    .teamId(teamId)
+                    .teamName(otherName)
+                    .type(hi.getHiType())
                     .userProfileDtos(userProfileDtos)
                     .age(averageAge)
                     .dateTime(dateTime)

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.enums.ActiveStatus;
 import com.gdg.z_meet.domain.meeting.entity.enums.Event;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
 import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.meeting.repository.HiRepository;
@@ -80,7 +81,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
 
         Team myTeam = teamRepository.findByTeamType(userId, team.getTeamType(), event)
                 .orElseThrow(() -> new BusinessException(Code.MY_TEAM_NOT_FOUND));
-        Boolean hi = hiRepository.existsByFromAndTo(myTeam, team);
+        Boolean hi = hiRepository.existsByFromIdAndToIdAndHiType(myTeam.getId(), team.getId(), HiType.TEAM);
 
         return MeetingConverter.toGetTeamDTO(user, team, users, hi);
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomCommandServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/RandomCommandServiceImpl.java
@@ -85,7 +85,7 @@ public class RandomCommandServiceImpl implements RandomCommandService {
                 .collect(Collectors.toList());
 
         if (matching.getMatchingStatus() == MatchingStatus.COMPLETE) {
-            chatRoomCommandService.addUserJoinChat(userIds);
+            chatRoomCommandService.addRandomUserJoinChat(userIds);
         }
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.gdg.z_meet.domain.user.repository;
 
+import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
@@ -44,4 +45,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.name = :name AND u.studentNumber = :studentNumber")
     Optional<User> findByNameAndStudentNumberWithProfile(String name, String studentNumber);
+
+
+    List<User> findByIdIn(List<Long> userIds);
 }

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -56,7 +56,7 @@ public enum Code implements BaseCode {
 
     //Hi Error
     HI_COUNT_ZERO(HttpStatus.BAD_REQUEST, "Hi4001","하이의 갯수가 0개 일 경우 하이를 보낼 수 없습니다."),
-    SAME_GENDER(HttpStatus.BAD_REQUEST, "Hi4002", "같은 성별의 팀에게는 하이를 보낼 수 없습니다."),
+    SAME_GENDER(HttpStatus.BAD_REQUEST, "Hi4002", "같은 성별에게는 하이를 보낼 수 없습니다."),
     HI_DUPLICATION(HttpStatus.BAD_REQUEST, "Hi4003", "이미 하이를 보낸 팀입니다."),
     HI_NOT_FOUND(HttpStatus.NOT_FOUND,"Hi4004","하이를 찾을 수 없습니다."),
 

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -59,6 +59,7 @@ public enum Code implements BaseCode {
     SAME_GENDER(HttpStatus.BAD_REQUEST, "Hi4002", "같은 성별에게는 하이를 보낼 수 없습니다."),
     HI_DUPLICATION(HttpStatus.BAD_REQUEST, "Hi4003", "이미 하이를 보낸 팀입니다."),
     HI_NOT_FOUND(HttpStatus.NOT_FOUND,"Hi4004","하이를 찾을 수 없습니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND,"HI4005", "해당 팀(유저)를 찾을 수 없습니다."),
 
     // Chat Error
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4001","채팅방을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- Feat/#178-chat

## ⚡️ 작업동기

- 1:1 하이, 채팅방 기능 추가 
- 2:2 랜텀미팅 수정 

## 🔑 주요 변경사항

- 1:1 하이 기능 추가 -> hi 엔티티에서 hi_type 필드 추가 ("USER", "TEAM") 
- 1:1 채팅 기능 추가 -> chat_room 엔티티에서 chat_type 변경("USER" 추가됨)
  - 예시 코드) `ALTER TABLE chat_room MODIFY COLUMN chat_type ENUM('RANDOM', 'TEAM', 'USER') NOT NULL;`
- 2:2 랜덤미팅으로 수정
- 랜덤미팅 방 id를 db에서 조회하는 것이 아닌 레디스에 저장해서 조회하도록 수정. 만약 레디스에 값이 없을 경우 db 조회
- 채팅 메시지 모두 몽고db에 저장. 최근 메시지는 레디스에서 가져옴.
- 그 외 코드 리팩토링 (중복 코드 하나로 합치기 등) 


## 💡 관련 이슈

- #178