### PR TITLE
[FEAT] Controller 사용자 인증 처리 로직 커스터마이징

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ out/
 .env
 
 nginx/nginx.conf
+src/main/java/com/gdg/z_meet/global/firebase/zi-meet-firebase-adminsdk-fbsvc-f026a2abf0.json
 
 ### Mac OS ###
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta:2.17.1'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+	// firebase
+	implementation 'com.google.firebase:firebase-admin:9.2.0'           // Google Firebase Admin
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
 }
 
 // plain jar 생성 X 설정

--- a/src/main/java/com/gdg/z_meet/global/config/WebConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/WebConfig.java
@@ -1,14 +1,31 @@
 package com.gdg.z_meet.global.config;
 
+import com.gdg.z_meet.global.jwt.AuthUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import java.util.List;
+
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver userIdArgumentResolver;
+
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addRedirectViewController("/swagger", "/swagger-ui/index.html");
         registry.addRedirectViewController("/swagger/", "/swagger-ui/index.html");
+    }
+
+    public WebConfig(AuthUserArgumentResolver userIdArgumentResolver) {
+        this.userIdArgumentResolver = userIdArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
     }
 }

--- a/src/main/java/com/gdg/z_meet/global/jwt/AuthUserArgumentResolver.java
+++ b/src/main/java/com/gdg/z_meet/global/jwt/AuthUserArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.gdg.z_meet.global.jwt;
+
+import com.gdg.z_meet.global.security.AuthUser;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(AuthUser.class) != null
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
+
+        String token = ((HttpServletRequest) webRequest.getNativeRequest())
+                .getHeader("Authorization");
+
+        // JWT 파싱 → userId 추출
+        return jwtUtil.getUserIdFromToken(token);
+    }
+}

--- a/src/main/java/com/gdg/z_meet/global/jwt/JwtUtil.java
+++ b/src/main/java/com/gdg/z_meet/global/jwt/JwtUtil.java
@@ -138,6 +138,10 @@ public class JwtUtil {
     }
 
     public Long getUserIdFromToken(String token) {
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7).trim();      // user_id 파싱을 위한 Bearer 제거
+        }
+
         return jwtParser.parseClaimsJws(token).getBody().get("user_id", Long.class);
     }
 

--- a/src/main/java/com/gdg/z_meet/global/security/AuthUser.java
+++ b/src/main/java/com/gdg/z_meet/global/security/AuthUser.java
@@ -10,5 +10,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(hidden = true)
-public @interface UserId {
+public @interface AuthUser {
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- 

## ⚡️ 작업동기

- 인증된 사용자의 정보 주입 방식 커스텀


## 🔑 주요 변경사항

`Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();` 기존에는 유틸 클래스를 컨트롤러 내부에서 직접 호출해 SecurityContext에서 ID 추출하는 방식을 사용해왔는데,

해당 방식은 컨트롤러 내부에서 인증 정보를 다뤄야 하므로 SRP에 맞지 않았고, 테스트 코드 작성 시, SecurityContext 를 구성해줘야하므로 Mocking이 불가능한 단점이 있다고 판단되어, 커스텀 어노테이션 `@AuthUser` 를 구현하였습니다.

사용 방법은 `@AuthUser User user` 처럼 컨트롤러 파라미터로 주입해서 사용하시면 됩니다. 

## 💡 관련 이슈

- 