### PR TITLE
[FEAT][TEST] FCM 토큰 관리 및 관련 기능 단위 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,5 +81,5 @@ tasks.named('test') {
 }
 
 tasks.withType(Test) {
-	enabled = false    // 빌드 시 테스트 x
+	enabled = true    // 빌드 시 테스트 x
 }

--- a/build.gradle
+++ b/build.gradle
@@ -81,5 +81,5 @@ tasks.named('test') {
 }
 
 tasks.withType(Test) {
-	enabled = true    // 빌드 시 테스트 x
+	enabled = true
 }

--- a/src/main/java/com/gdg/z_meet/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/controller/FcmController.java
@@ -43,7 +43,7 @@ public class FcmController {
             @Parameter(name = "user", hidden = true)
     })
     @PostMapping("/token")
-    public Response<Long> saveFcmToken(@AuthUser Long userId, @RequestBody UserReq.saveFcmTokenReq req) {
+    public Response<Long> syncFcmToken(@AuthUser Long userId, @RequestBody UserReq.saveFcmTokenReq req) {
         fcmService.syncFcmToken(userId, req);
         return Response.ok(userId);
     }

--- a/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.gdg.z_meet.domain.user.dto.Token;
 import com.gdg.z_meet.domain.user.dto.UserReq;
 import com.gdg.z_meet.domain.user.dto.UserRes;
 import com.gdg.z_meet.domain.user.service.UserService;
+import com.gdg.z_meet.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,9 +42,9 @@ public class UserController {
 
     @DeleteMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃")
-    public Response<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-        userService.logout(request, response);
-        return Response.ok(null);
+    public Response<Void> logout(@RequestBody UserReq.logoutReq userReq, HttpServletRequest request, HttpServletResponse response) {
+        userService.logout(request, response, userReq.getFcmToken());
+        return Response.ok();
     }
 
     @GetMapping("/myprofile")

--- a/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
@@ -42,8 +42,8 @@ public class UserController {
 
     @DeleteMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃")
-    public Response<Void> logout(@RequestBody UserReq.logoutReq userReq, HttpServletRequest request, HttpServletResponse response) {
-        userService.logout(request, response, userReq.getFcmToken());
+    public Response<Void> logout(@RequestParam String fcmToken, HttpServletRequest request, HttpServletResponse response) {
+        userService.logout(request, response, fcmToken);
         return Response.ok();
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/user/dto/UserReq.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/dto/UserReq.java
@@ -98,13 +98,4 @@ public class UserReq {
     public static class saveFcmTokenReq{
         String fcmToken;
     }
-
-    @Builder
-    @Getter
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class logoutReq{
-        String fcmToken;
-    }
-
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/service/UserService.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.gdg.z_meet.domain.user.service;
 
 import com.gdg.z_meet.domain.chat.service.ChatRoomCommandService;
-import com.gdg.z_meet.domain.order.repository.ItemPurchaseRepository;
+import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
 import com.gdg.z_meet.domain.user.entity.UserProfile;
 import com.gdg.z_meet.domain.user.entity.enums.Level;
 import com.gdg.z_meet.domain.user.repository.RefreshTokenRepository;
@@ -36,8 +36,8 @@ public class UserService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
     private final BCryptPasswordEncoder encoder;
-    private final ItemPurchaseRepository itemPurchaseRepository;
     private final ChatRoomCommandService chatRoomCommandService;
+    private final FcmTokenRepository fcmTokenRepository;
 
     @Transactional
     public UserRes.SignUpRes signup(UserReq.SignUpReq signUpReq) {
@@ -105,12 +105,17 @@ public class UserService {
         return token;
     }
 
-    public void logout(HttpServletRequest request, HttpServletResponse response) {
+    public void logout(HttpServletRequest request, HttpServletResponse response, String fcmToken) {
         String refreshToken = jwtUtil.getRefreshTokenFromCookie(request);
         if (refreshToken != null) {
             refreshTokenRepository.delete(refreshToken);
         }
         clearRefreshTokenCookie(response);
+
+        // 해당 디바이스의 FCM 토큰만 삭제됨
+        if (fcmToken != null && !fcmToken.isBlank()) {
+            fcmTokenRepository.deleteByToken(fcmToken);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/gdg/z_meet/service/FcmServiceImplTest.java
+++ b/src/test/java/com/gdg/z_meet/service/FcmServiceImplTest.java
@@ -1,0 +1,96 @@
+package com.gdg.z_meet.service;
+
+import com.gdg.z_meet.domain.fcm.entity.FcmToken;
+import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
+import com.gdg.z_meet.domain.fcm.service.FcmServiceImpl;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import com.gdg.z_meet.global.exception.BusinessException;
+import com.gdg.z_meet.global.response.Code;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class FcmServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FcmTokenRepository fcmTokenRepository;
+
+    @InjectMocks
+    private FcmServiceImpl fcmService;
+
+    @Mock
+    private FirebaseMessaging firebaseMessaging;
+
+    @Test
+    void sendFcmMessage_유효한_토큰이면_성공적으로_전송됨() throws Exception {
+        // given
+        Long userId = 1L;
+        String token = "유효한 토큰";
+        String title = "알림 제목";
+        String body = "알림 내용";
+
+        User user = User.builder().id(userId).build();
+        FcmToken deviceToken = FcmToken.builder().token(token).user(user).build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(fcmTokenRepository.findAllByUser(user)).thenReturn(List.of(deviceToken));
+
+        // FirebaseMessaging.getInstance() mocking
+        try (MockedStatic<FirebaseMessaging> firebaseStatic = Mockito.mockStatic(FirebaseMessaging.class)) {
+            firebaseStatic.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
+            when(firebaseMessaging.send(any(Message.class))).thenReturn("알림 전송에 성공하셨습니다 !!!");
+
+            // when
+            fcmService.sendFcmMessage(userId, title, body);
+
+            // then
+            verify(firebaseMessaging, times(1)).send(any(Message.class));  // 한 번만 호출되었는지 확인
+        }
+    }
+
+    @Test
+    void sendFcmMessage_유효하지_않은_토큰이면_삭제됨() throws Exception {
+        // given
+        Long userId = 1L;
+        String token = "invalid-token";
+        String title = "제목";
+        String body = "내용";
+
+        User user = User.builder().id(userId).build();
+        FcmToken deviceToken = FcmToken.builder().token(token).user(user).build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(fcmTokenRepository.findAllByUser(user)).thenReturn(List.of(deviceToken));
+
+        // FirebaseMessaging.getInstance() 모킹
+        try (MockedStatic<FirebaseMessaging> firebaseStatic = Mockito.mockStatic(FirebaseMessaging.class)) {
+            firebaseStatic.when(FirebaseMessaging::getInstance).thenReturn(firebaseMessaging);
+            when(firebaseMessaging.send(any(Message.class))).thenThrow(new BusinessException(Code.FCM_SEND_MESSAGE_ERROR));
+
+            // when
+            fcmService.sendFcmMessage(userId, title, body);
+
+            // then
+            verify(fcmTokenRepository).delete(deviceToken);  // 무효 토큰 삭제 확인
+        }
+    }
+}


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #187 

## ⚡️ 작업동기

- 

## 🔑 주요 변경사항

1. 기존에 백엔드 내에서 쿠키 만료를 통해 로그아웃을 진행하였는데, 현재 디바이스의 토큰에 대해서만 삭제가 필요하므로, 프론트 측에서 FCM 토큰 값을 받아오도록 하여 로그아웃 시, 사용자의 FCM 토큰이 유효하다면 삭제합니다. 

DB 에서 FCM 토큰을 꺼내는 방식을 택하지 않은 이유는 아래와 같습니다.
- JWT에는 디바이스 정보가 없음.
- DB에서 모든 토큰을 조회(특정 디바이스 식별이 안되기 때문)하여 삭제하면 다른 디바이스의 푸시까지 차단되는 이슈가 생김
- 서버는 클라이언트가 알려주는 FCM 토큰만을 삭제하면 되므로, 책임 분리 명확


2. FCM에 대한 테스트는 별도의 테스트 토큰 없이 실제 디바이스 환경에서 진행해야 하기에, Mocking 을 통해 실제 Firebase 호출 없이도 최대한 비슷한 환경을 구성하여 단위 테스트를 진행하였습니다. 

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/3acdaf86-dfd3-4faf-ac13-7d7206730044" />



## 💡 관련 이슈

- 

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!