### PR TITLE
[REFACTOR] FCM 토큰 전달 방식 쿼리 파라미터 -> 커스텀 헤더로 변경

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/controller/FcmController.java
@@ -1,10 +1,8 @@
 package com.gdg.z_meet.domain.fcm.controller;
 
-import com.gdg.z_meet.domain.fcm.dto.FcmSendReq;
 import com.gdg.z_meet.domain.fcm.dto.FcmTestReq;
 import com.gdg.z_meet.domain.fcm.service.FcmService;
 import com.gdg.z_meet.domain.user.dto.UserReq;
-import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.global.response.Response;
 import com.gdg.z_meet.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/gdg/z_meet/domain/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/repository/FcmTokenRepository.java
@@ -9,9 +9,7 @@ import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
-    Optional<FcmToken> findByUser(User user);
-
-    void deleteByUser(User user);
+    void deleteAllByUser(User user);
 
     boolean existsByUserAndToken(User user, String token);
 

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/FcmServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/FcmServiceImpl.java
@@ -39,8 +39,12 @@ public class FcmServiceImpl implements FcmService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(Code.USER_NOT_FOUND));
 
-        List<FcmToken> tokens = fcmTokenRepository.findAllByUser(user);
+        if (!user.isPushAgree()) {
+            log.info("푸시 알림 비동의 상태: userId={}", userId);
+            return;
+        }
 
+        List<FcmToken> tokens = fcmTokenRepository.findAllByUser(user);
         if (tokens.isEmpty()) {
             log.warn("FCM 토큰 없음: userId={}", userId);
             return;

--- a/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
 
     @DeleteMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃")
-    public Response<Void> logout(@RequestParam String fcmToken, HttpServletRequest request, HttpServletResponse response) {
+    public Response<Void> logout(@RequestHeader(value = "X-FCM-TOKEN", required = false) String fcmToken, HttpServletRequest request, HttpServletResponse response) {
         userService.logout(request, response, fcmToken);
         return Response.ok();
     }

--- a/src/main/java/com/gdg/z_meet/domain/user/service/UserService.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/service/UserService.java
@@ -206,6 +206,8 @@ public class UserService {
 
         chatRoomCommandService.removeUser(userId);
 
+        fcmTokenRepository.deleteAllByUser(user);
+
         user.setIsDeleted(true);
         userRepository.save(user);
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #177 

## ⚡️ 작업동기

- 

## 🔑 주요 변경사항

- 로그아웃이 DELETE 타입으로 구현되어 있어서, FCM 토큰이 그렇게 민감한 정보는 아니기도 하고 RESTFUL 하게 파라미터로 넘기려고 했지만 헤더를 커스텀하여 넘기는 방식으로 변경 
- 회원 탈퇴 시, 디바이스 구분 없이 FCM 토큰 전부 삭제 
- 알림 생성 메서드에 사용자 동의 여부에 대한 검증이 빠져 있었어서 추가

## 💡 관련 이슈

- 

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!