### PR TITLE
[FEAT] 1대1 미팅 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -9,6 +9,7 @@ import com.gdg.z_meet.domain.meeting.service.MeetingCommandService;
 import com.gdg.z_meet.domain.meeting.service.MeetingQueryService;
 import com.gdg.z_meet.global.common.AuthenticatedUserUtils;
 import com.gdg.z_meet.global.response.Response;
+import com.gdg.z_meet.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
@@ -158,6 +159,15 @@ public class MeetingController {
 
         Long userId = AuthenticatedUserUtils.getAuthenticatedUserId();
         MeetingResponseDTO.GetMyDeleteDTO response = meetingQueryService.getMyDelete(userId);
+
+        return Response.ok(response);
+    }
+
+    @Operation(summary = "1대1 갤러리 조회", description = "12명씩 페이징 됩니다.")
+    @GetMapping("/ONE_TO_ONE")
+    public Response<MeetingResponseDTO.GetUserGalleryDTO> getUserGallery(@AuthUser Long userId, @RequestParam(name = "page") Integer page) {
+
+        MeetingResponseDTO.GetUserGalleryDTO response = meetingQueryService.getUserGallery(userId, page);
 
         return Response.ok(response);
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/converter/MeetingConverter.java
@@ -4,6 +4,7 @@ import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.UserProfile;
 
 import java.util.List;
 import java.util.Map;
@@ -138,6 +139,28 @@ public class MeetingConverter {
 
         return MeetingResponseDTO.GetMyDeleteDTO.builder()
                 .leftDelete(user.getUserProfile().getLeftDelete())
+                .build();
+    }
+
+    public static MeetingResponseDTO.GetUserGalleryDTO toGetUserGalleryDTO(List<User> userList){
+
+        List<MeetingResponseDTO.GetPreUserDTO> userDTOS = userList.stream()
+                .map(user -> {
+                    UserProfile profile = user.getUserProfile();
+                    return MeetingResponseDTO.GetPreUserDTO.builder()
+                            .userId(user.getId())
+                            .emoji(profile.getEmoji())
+                            .name(user.getName())
+                            .verification(profile.getVerification() == COMPLETE ? 1 : 0)
+                            .major(profile.getMajor().getShortName())
+                            .age(profile.getAge())
+                            .music(String.valueOf(profile.getMusic()))
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return MeetingResponseDTO.GetUserGalleryDTO.builder()
+                .userList(userDTOS)
                 .build();
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingResponseDTO.java
@@ -174,4 +174,26 @@ public class MeetingResponseDTO {
     public static class GetVerificationDTO {
         List<GetVerificationTeamDTO> teamList;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPreUserDTO {
+        Long userId;
+        String emoji;
+        String name;
+        Integer verification;
+        String major;
+        Integer age;
+        String music;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetUserGalleryDTO {
+        List<GetPreUserDTO> userList;
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryService.java
@@ -7,10 +7,14 @@ public interface MeetingQueryService {
 
     MeetingResponseDTO.GetTeamGalleryDTO getTeamGallery(Long userId, TeamType teamType, Integer page);
     MeetingResponseDTO.GetTeamDTO getTeam(Long userId, Long teamId);
+
     MeetingResponseDTO.GetPreMyTeamDTO getPreMyTeam(Long userId, TeamType teamType);
     MeetingResponseDTO.GetMyTeamDTO getMyTeam(Long userId, TeamType teamType);
     MeetingResponseDTO.GetMyTeamHiDTO getMyTeamHi(Long userId, TeamType teamType);
+
     MeetingResponseDTO.CheckNameDTO checkName(String name);
     MeetingResponseDTO.GetSearchListDTO getSearch(Long userId, TeamType teamType, String nickname, String phoneNumber);
     MeetingResponseDTO.GetMyDeleteDTO getMyDelete(Long userId);
+
+    MeetingResponseDTO.GetUserGalleryDTO getUserGallery(Long userId, Integer page);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -12,11 +12,13 @@ import com.gdg.z_meet.domain.meeting.repository.HiRepository;
 import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
 import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.UserProfile;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
 import com.gdg.z_meet.domain.user.repository.UserProfileRepository;
 import com.gdg.z_meet.domain.user.repository.UserRepository;
 import com.gdg.z_meet.global.exception.BusinessException;
 import com.gdg.z_meet.global.response.Code;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -179,6 +181,22 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
 
         return MeetingConverter.toGetMyDeleteDTO(user);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MeetingResponseDTO.GetUserGalleryDTO getUserGallery(Long userId, Integer page) {
+
+        UserProfile userProfile = userProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(Code.USER_PROFILE_NOT_FOUND));
+
+        Gender gender = userProfile.getGender();
+        List<User> userList = userRepository.findAllByIsVisible(userId, gender, PageRequest.of(page, 12));
+        Collections.shuffle(userList);
+
+        return MeetingConverter.toGetUserGalleryDTO(userList);
+    }
+
+
 
     private Map<Long, List<String>> collectEmoji(List<Team> teamList) {
 

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -1,10 +1,9 @@
 package com.gdg.z_meet.domain.user.entity;
 
+import com.gdg.z_meet.domain.meeting.entity.enums.Verification;
 import com.gdg.z_meet.domain.user.entity.enums.*;
 import jakarta.persistence.*;
 import lombok.*;
-
-import static com.gdg.z_meet.domain.user.entity.enums.Level.LIGHT;
 
 @Entity
 @Getter
@@ -79,6 +78,11 @@ public class UserProfile {
     @Column(nullable = false)
     @Builder.Default
     private boolean isVisible = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Verification verification = Verification.NONE;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -72,6 +72,14 @@ public class UserProfile {
     @Builder.Default
     private int ticket = 2;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int hi = 2;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isVisible = false;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package com.gdg.z_meet.domain.user.repository;
 
 import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.enums.Event;
 import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.entity.enums.Gender;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.NoRepositoryBean;
@@ -49,4 +51,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNameAndStudentNumberAndPhoneNumber(String name, String studentNumber, String phoneNumber);
 
     List<User> findByIdIn(List<Long> userIds);
+
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up " +
+            "WHERE u.id != :userId AND up.gender != :gender AND up.isVisible = true " +
+            "ORDER BY FUNCTION('RAND')")
+    List<User> findAllByIsVisible(@Param("userId") Long userId, @Param("gender") Gender gender, Pageable pageable);
+
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#179_meeting

## ⚡️ 작업동기

- 1대1 미팅 로직 구현

## 🔑 주요 변경사항

- POST /meeting/ONE_TO_ONE API 개발
- 엔티티 변경사항
- UserProfile에 hi, is_visible, verification 컬럼 추가
- 갤러리 조회 시 랜덤 정렬 기능은 다른 브랜치에서 수정하겠습니다 :)

## 💡 관련 이슈

- #179 

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!