### PR TITLE
[FEAT] 1:1 & 2:2 매칭 및 미팅 관련 FCM 알림 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,12 @@ dependencies {
 	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.1")
 
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 // plain jar 생성 X 설정
@@ -82,4 +88,8 @@ tasks.named('test') {
 
 tasks.withType(Test) {
 	enabled = true
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/service/ChatRoomCommandService.java
@@ -11,7 +11,6 @@ import com.gdg.z_meet.domain.chat.repository.ChatRoomRepository;
 import com.gdg.z_meet.domain.chat.repository.JoinChatRepository;
 import com.gdg.z_meet.domain.chat.repository.mongo.MongoMessageRepository;
 import com.gdg.z_meet.domain.chat.repository.TeamChatRoomRepository;
-import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
 import com.gdg.z_meet.domain.meeting.entity.Hi;
 import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
@@ -19,9 +18,7 @@ import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
 import com.gdg.z_meet.domain.meeting.repository.HiRepository;
 import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
-import com.gdg.z_meet.domain.meeting.service.HiCommandService;
 import com.gdg.z_meet.domain.meeting.service.HiCommandServiceImpl;
-import com.gdg.z_meet.domain.meeting.service.HiQueryServiceImpl;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.repository.UserRepository;
 import com.gdg.z_meet.global.exception.BusinessException;
@@ -123,7 +120,7 @@ public class ChatRoomCommandService {
 
         Hi hi = hiRepository.findByFromIdAndToIdAndHiStatus(from.getId(), to.getId(), HiStatus.NONE);
         if (hi == null) throw new BusinessException(Code.HI_NOT_FOUND);
-        hi.changeStatus(HiStatus.ACCEPT);
+        hi.setChangeStatus(HiStatus.ACCEPT);
         hiRepository.save(hi);
 
         //채팅방 생성
@@ -156,7 +153,7 @@ public class ChatRoomCommandService {
 
         Hi hi = hiRepository.findByFromIdAndToIdAndHiStatus(from.getId(), to.getId(), HiStatus.NONE);
         if (hi == null) throw new BusinessException(Code.HI_NOT_FOUND);
-        hi.changeStatus(HiStatus.ACCEPT);
+        hi.setChangeStatus(HiStatus.ACCEPT);
         hiRepository.save(hi);
 
         //채팅방 생성
@@ -220,18 +217,18 @@ public class ChatRoomCommandService {
             // Redis에 참여 여부가 있는지 먼저 체크
             String joinChatsKey = "user:" + userId + ":chatrooms";
               // 새로운 User 정보 DB 저장 (배치 인서트로 한 번에 저장)
-                newJoinChats.add(JoinChat.builder()
-                        .user(user)
-                        .chatRoom(chatRoom)
-                        .status(JoinChatStatus.ACTIVE)
-                        .build());
+            newJoinChats.add(JoinChat.builder()
+                    .user(user)
+                    .chatRoom(chatRoom)
+                    .status(JoinChatStatus.ACTIVE)
+                    .build());
 
-                // 사용자 -> 참여 채팅방 매핑 데이터 Redis 저장
-                redisTemplate.opsForSet().add(joinChatsKey, String.valueOf(chatRoomId));
+            // 사용자 -> 참여 채팅방 매핑 데이터 Redis 저장
+            redisTemplate.opsForSet().add(joinChatsKey, String.valueOf(chatRoomId));
 
-                // 채팅방 -> 참여 사용자 매핑 데이터 Redis 저장
-                String chatRoomUsersKey = "chatroom:" + chatRoomId + ":users";
-                redisTemplate.opsForSet().add(chatRoomUsersKey, String.valueOf(userId));
+            // 채팅방 -> 참여 사용자 매핑 데이터 Redis 저장
+            String chatRoomUsersKey = "chatroom:" + chatRoomId + ":users";
+            redisTemplate.opsForSet().add(chatRoomUsersKey, String.valueOf(userId));
 
         }
 

--- a/src/main/java/com/gdg/z_meet/domain/fcm/feign/FcmFeignClient.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/feign/FcmFeignClient.java
@@ -1,0 +1,16 @@
+//package com.gdg.z_meet.domain.fcm.feign;
+//
+//import org.springframework.cloud.openfeign.FeignClient;
+//import org.springframework.stereotype.Component;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestHeader;
+//
+//// FCM 토큰 조회 후, Firebase 서버에 알림 전송
+//@FeignClient(name = "FCMFeign", url = "https://fcm.googleapis.com", configuration = FcmFeignConfig.class)
+//@Component
+//public interface FcmFeignClient {
+//
+//    @PostMapping("/v1/projects/zi-meet/messages:send")
+//    FcmFeignRes getFCMResponse(@RequestHeader("Authorization") String token, @RequestBody String fcmMessage);
+//}

--- a/src/main/java/com/gdg/z_meet/domain/fcm/feign/FcmFeignConfig.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/feign/FcmFeignConfig.java
@@ -1,0 +1,28 @@
+//package com.gdg.z_meet.domain.fcm.feign;
+//
+//import com.gdg.z_meet.global.exception.FeignClientExceptionErrorDecoder;
+//import feign.Logger;
+//import feign.RequestInterceptor;
+//import feign.codec.ErrorDecoder;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.context.annotation.Bean;
+//
+//@RequiredArgsConstructor
+//public class FcmFeignConfig {
+//
+//    @Bean
+//    public RequestInterceptor requestInterceptor(){
+//        // 모든 요청에 Content-Type: application/json;charset=UTF-8(JSON 형식 + 한글 깨짐 방지)  자동 추가
+//        return template -> template.header("Content-Type", "application/json;charset=UTF-8");
+//    }
+//
+//    @Bean
+//    public ErrorDecoder errorDecoder() {
+//        return  new FeignClientExceptionErrorDecoder();
+//    }
+//
+//    @Bean
+//    Logger.Level feignLoggerLevel() {
+//        return Logger.Level.FULL;
+//    }
+//}

--- a/src/main/java/com/gdg/z_meet/domain/fcm/feign/FcmFeignRes.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/feign/FcmFeignRes.java
@@ -1,0 +1,12 @@
+//package com.gdg.z_meet.domain.fcm.feign;
+//
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//import lombok.Setter;
+//
+//@Getter
+//@Setter
+//@NoArgsConstructor
+//public class FcmFeignRes {
+//    String name;     // 전송 확인 여부를 위한 메시지 ID
+//}

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/FcmMessageClient.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/FcmMessageClient.java
@@ -1,0 +1,82 @@
+package com.gdg.z_meet.domain.fcm.service;
+
+import com.gdg.z_meet.domain.fcm.entity.FcmToken;
+import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import com.gdg.z_meet.global.exception.BusinessException;
+import com.gdg.z_meet.global.response.Code;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmMessageClient {
+
+    private final UserRepository userRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Transactional
+    public void sendFcmMessage(Long userId, String title, String body ) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(Code.USER_NOT_FOUND));
+
+        if (!user.isPushAgree()) {
+            log.info("푸시 알림 비동의 상태: userId={}", userId);
+            return;
+        }
+
+        List<FcmToken> tokens = fcmTokenRepository.findAllByUser(user);
+        if (tokens.isEmpty()) {
+            log.warn("FCM 토큰 없음: userId={}", userId);
+            return;
+        }
+
+        // 유저 당 디바이스는 많아야 3개로 예상되므로 , for 문으로 순차 처리
+        for (FcmToken deviceToken : tokens) {
+            String token = deviceToken.getToken();
+            log.info("FCM 전송 대상 토큰: {}", token);
+
+            Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .build();
+
+            try {
+                String response = FirebaseMessaging.getInstance().send(message);   // FCM 서버에 메시지 전송
+                log.info("FCM 전송 성공: {}", response);
+            } catch (FirebaseMessagingException e) {
+                log.warn("FCM 전송 실패: {}", e.getMessage(), e);
+
+                Set<String> deletableErrorCodes = Set.of(
+                        "registration-token-not-registered",
+                        "invalid-argument",
+                        "messaging/invalid-registration-token",
+                        "unregistered"
+                );
+
+                // 해당 에러 코드일 경우 토큰 삭제
+                if (deletableErrorCodes.contains(e.getErrorCode())) {
+                    fcmTokenRepository.delete(deviceToken);
+                    log.warn("무효한 FCM 토큰 삭제: token={}, userId={}", token, user.getId());
+                }
+
+                // 예외 throw 하지 않으므로, 하나 전송 실패해도 계속해서 나머지 토큰에는 알림 발송
+            }
+        }
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmChatMessageService.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmChatMessageService.java
@@ -1,0 +1,11 @@
+package com.gdg.z_meet.domain.fcm.service.custom;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmChatMessageService {
+}

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmMeetingMessageService.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmMeetingMessageService.java
@@ -1,0 +1,157 @@
+package com.gdg.z_meet.domain.fcm.service.custom;
+
+import com.gdg.z_meet.domain.fcm.service.FcmMessageClient;
+import com.gdg.z_meet.domain.meeting.repository.HiRepository;
+import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
+import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
+import com.gdg.z_meet.domain.meeting.service.HiQueryService;
+import com.gdg.z_meet.domain.meeting.service.HiQueryServiceImpl;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.UserProfile;
+import com.gdg.z_meet.domain.user.repository.UserProfileRepository;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmMeetingMessageService {
+
+    private final UserProfileRepository userProfileRepository;
+    private final TeamRepository teamRepository;
+    private final UserTeamRepository userTeamRepository;
+    private final HiRepository hiRepository;
+
+
+    private final FcmMessageClient fcmMessageClient;
+    private final HiQueryService hiQueryService;
+
+    @Transactional
+    @Scheduled(fixedRate = 3600000)      // 1시간마다 실행
+    public void messagingNoneMeetingOneOneUsers() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+        List<UserProfile> users = userProfileRepository.findInactiveUsers(threshold);
+
+        String title = "👀 아직 내 프로필이 활성화되지 않았어요.";
+        String body = "‘1대1 참여하기’ 버튼으로 내 프로필을 활성화해야 이성이 볼 수 있어요!";
+
+        for (UserProfile user : users) {
+            try {
+                fcmMessageClient.sendFcmMessage(user.getId(), title, body);
+                user.setFcmSendOneOne(true);
+            } catch (Exception e) {
+                log.error("1:1 FCM 메시지 전송 실패 - userId: {}, error: {}", user.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    @Transactional
+    @Scheduled(fixedRate = 3600000)      // 1시간마다 실행
+    public void messagingNoneMeetingTwoTwoUsers() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+        List<User> users = teamRepository.findUsersNotInTwoToTwoTeam(threshold);
+
+        String title = "👀 아직 2대2 팀을 만들지 않으셨네요!";
+        String body = "마음 맞는 친구와 팀을 만들어보세요. 함께하면 매칭 확률이 훨씬 높아져요 🔥";
+
+        for (User user : users) {
+            try {
+                fcmMessageClient.sendFcmMessage(user.getId(), title, body);
+                user.setFcmSendTwoTwo(true);
+            } catch (Exception e) {
+                log.error("2:2 FCM 메시지 전송 실패 - userId: {}, error: {}", user.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    ////////////////
+
+    // 하이 보내기 호출 시, 실행되므로 스케줄링 적용 하지 않음
+    public void messagingHiToUser(Long userId) {
+        if (userId == null) { return ;}
+
+        String title = "❤️나에게 하이가 도착했어요! 💌";
+        String body = "ZI밋에서 어떤 사람에게 하이가 왔는지 확인해보세요!";
+
+        try {
+            fcmMessageClient.sendFcmMessage(userId, title, body);
+        } catch (Exception e) {
+            log.error("FCM 하이(유저) 메시지 전송 실패 - userId: {}, error: {}", userId, e.getMessage(), e);
+        }
+    }
+
+    @Transactional
+    @Scheduled(fixedRate = 60000)    // 1분 마다
+    public void messagingNotAcceptHiToUser() {
+        List<Long> userIds = hiRepository.findUserIdsToNotGetHi();
+
+        if (userIds.isEmpty()) return;
+
+        String title = "혹시 받은 하이를 잊으셨나요? 🥺";
+        String body = "받은 하이는 ⏰5시간 후에 사라지니 빠르게 확인해보세요!";
+
+        for (Long userId : userIds) {
+            try {
+                hiQueryService.checkHiList(userId, "Receive");
+                fcmMessageClient.sendFcmMessage(userId, title, body);
+            } catch (Exception e) {
+                log.error(" FCM 받은 하이 여부 메시지 전송 실패 userId: {}, message: {}", userId, e.getMessage(), e);
+            }
+        }
+    }
+
+    ////////////////
+
+
+    // 하이 보내기 호출 시, 실행되므로 스케줄링 적용 하지 않음
+    public void messagingHiToTeam(Long teamId) {
+        if (teamId == null) { return ;}
+
+        List<Long> userIds = userTeamRepository.findUserIdsByTeamId(teamId);
+
+        String title = "❤️우리 팀에게 하이가 도착했어요! 💌";
+        String body = "ZI밋에서 어떤 팀에게 하이가 왔는지 확인해보세요! ";
+
+        for (Long userId : userIds) {
+            try {
+                fcmMessageClient.sendFcmMessage(userId, title, body);
+            } catch (Exception e) {
+                log.error("FCM 하이(팀) 메시지 전송 실패 - userId: {}, error: {}", userId, e.getMessage(), e);
+            }
+        }
+    }
+
+    @Transactional
+    @Scheduled(fixedRate = 60000)  // 1분 마다
+    public void messagingNotAcceptHiToTeam() {
+
+        List<Long> teamIds = hiRepository.findTeamIdToNotGetHi();
+
+        if (teamIds.isEmpty()) return;
+
+        List<Long> userIds = userTeamRepository.findUserIdsByTeamIds(teamIds);
+
+        for (Long userId : userIds) {
+            try {
+                hiQueryService.checkHiList(userId, "Receive");
+
+                String title = "혹시 받은 하이를 잊으셨나요? 🥺";
+                String body = "받은 하이는 ⏰5시간 후에 사라지니 빠르게 확인해보세요!";
+                fcmMessageClient.sendFcmMessage(userId, title, body);
+            } catch (Exception e) {
+                log.error(" FCM 받은 하이 여부 메시지 전송 실패 userId: {}, message: {}", userId, e.getMessage(), e);
+            }
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmMeetingMessageService.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmMeetingMessageService.java
@@ -1,6 +1,7 @@
 package com.gdg.z_meet.domain.fcm.service.custom;
 
 import com.gdg.z_meet.domain.fcm.service.FcmMessageClient;
+import com.gdg.z_meet.domain.meeting.entity.enums.Event;
 import com.gdg.z_meet.domain.meeting.repository.HiRepository;
 import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
 import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
@@ -57,7 +58,8 @@ public class FcmMeetingMessageService {
     @Scheduled(fixedRate = 3600000)      // 1시간마다 실행
     public void messagingNoneMeetingTwoTwoUsers() {
         LocalDateTime threshold = LocalDateTime.now().minusHours(24);
-        List<User> users = teamRepository.findUsersNotInTwoToTwoTeam(threshold);
+        Event event = Event.AU_2025;
+        List<User> users = teamRepository.findUsersNotInTwoToTwoTeam(threshold, event);
 
         String title = "👀 아직 2대2 팀을 만들지 않으셨네요!";
         String body = "마음 맞는 친구와 팀을 만들어보세요. 함께하면 매칭 확률이 훨씬 높아져요 🔥";

--- a/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/controller/MeetingController.java
@@ -104,14 +104,14 @@ public class MeetingController {
 
     @Operation(summary = "하이 보내기")
     @PostMapping("/hi/send")
-    public Response<String> sendHi(@RequestBody MeetingRequestDTO.hiDto hiDto){
+    public Response<String> sendHi(@RequestBody MeetingRequestDTO.HiDto hiDto){
         hiCommandService.sendHi(hiDto);
         return Response.ok(hiDto.getToId() +"팀에게 하이가 보내졌습니다. ");
     }
 
     @Operation(summary = "하이 거절하기")
     @PatchMapping("/hi/refuse")
-    public Response<String> refuseHi(@RequestBody MeetingRequestDTO.hiDto hiDto){
+    public Response<String> refuseHi(@RequestBody MeetingRequestDTO.HiDto hiDto){
         hiCommandService.refuseHi(hiDto);
         return Response.ok(hiDto.getFromId() +"팀이 보낸 하이가 거절되었습니다. ");
     }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/dto/MeetingRequestDTO.java
@@ -19,7 +19,7 @@ public class MeetingRequestDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class hiDto {
+    public static class HiDto {
         Long toId;
         Long fromId;
         HiType type; //USER or TEAM

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Hi.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Hi.java
@@ -32,8 +32,16 @@ public class Hi extends BaseEntity {
     @Column(name = "to_id")
     private Long toId;
 
+    @Column(nullable = false)
+    @Builder.Default
+    boolean fcmSendHiToUser = false;
+
+    @Column(nullable = false)
+    @Builder.Default
+    boolean fcmSendHiToTeam = false;
+
     // hi Status 변경
-    public void changeStatus(HiStatus hiStatus) {
+    public void setChangeStatus(HiStatus hiStatus) {
        this.hiStatus=hiStatus;
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 
-public interface HiRepository extends JpaRepository<Hi,Long> {
+public interface HiRepository extends JpaRepository<Hi,Long>, HiRepositoryCustom {
     Boolean existsByFromIdAndToIdAndHiStatusNotAndHiType(Long from, Long to, HiStatus status, HiType hiType);
     Hi findByFromIdAndToIdAndHiStatus(Long from, Long to, HiStatus status);
     @Query("SELECT DISTINCT h FROM Hi h WHERE h.toId IN (:teamIds) AND h.hiStatus='NONE' ORDER BY h.createdAt DESC")

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryCustom.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryCustom.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 public interface HiRepositoryCustom {
     List<Long> findUserIdsToNotGetHi();
+    List<Long> findTeamIdToNotGetHi();
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryCustom.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.gdg.z_meet.domain.meeting.repository;
+
+import java.util.List;
+
+public interface HiRepositoryCustom {
+    List<Long> findUserIdsToNotGetHi();
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.gdg.z_meet.domain.meeting.repository;
+
+import com.gdg.z_meet.domain.meeting.entity.QHi;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
+import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@RequiredArgsConstructor
+public class HiRepositoryImpl implements HiRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Long> findUserIdsToNotGetHi() {
+
+        QHi hi = QHi.hi;
+
+        LocalDateTime fourHoursAgo = LocalDateTime.now().minusHours(4);
+        LocalDateTime fourHoursAgoToMinute = fourHoursAgo.withSecond(0).withNano(0);
+
+        return queryFactory
+                .select(hi.toId)
+                .from(hi)
+                .where(
+                        hi.hiType.eq(HiType.USER),
+                        hi.hiStatus.eq(HiStatus.NONE),
+                        hi.fcmSendHiToUser.eq(false),
+                        hi.createdAt.between(fourHoursAgoToMinute, fourHoursAgoToMinute.plusMinutes(1))
+                )
+                .distinct()
+                .fetch();
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepositoryImpl.java
@@ -35,4 +35,25 @@ public class HiRepositoryImpl implements HiRepositoryCustom {
                 .distinct()
                 .fetch();
     }
+
+    @Override
+    public List<Long> findTeamIdToNotGetHi() {
+
+        QHi hi = QHi.hi;
+
+        LocalDateTime fourHoursAgo = LocalDateTime.now().minusHours(4);
+        LocalDateTime fourHoursAgoToMinute = fourHoursAgo.withSecond(0).withNano(0);
+
+        return queryFactory
+                .select(hi.toId)
+                .from(hi)
+                .where(
+                        hi.hiType.eq(HiType.TEAM),
+                        hi.hiStatus.eq(HiStatus.NONE),
+                        hi.fcmSendHiToTeam.eq(false),
+                        hi.createdAt.between(fourHoursAgoToMinute, fourHoursAgoToMinute.plusMinutes(1))
+                )
+                .distinct()
+                .fetch();
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -47,9 +47,10 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT u FROM User u " +
             "WHERE u.createdAt <= :threshold " +
+            "AND u.fcmSendTwoTwo = false " +
             "AND u.id NOT IN (" +
             "   SELECT ut.user.id FROM UserTeam ut " +
-            "   WHERE ut.team.teamType = 'TWO_TO_TWO'" +
+            "   WHERE ut.team.teamType = 'TWO_TO_TWO' AND ut.team.event = :event " +
             ")")
-    List<User> findUsersNotInTwoToTwoTeam(@Param("threshold") LocalDateTime threshold);
+    List<User> findUsersNotInTwoToTwoTeam(@Param("threshold") LocalDateTime threshold, @ Param("event") Event event);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/TeamRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,4 +43,13 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t JOIN UserTeam ut ON t.id = ut.team.id WHERE ut.user = :user AND t.event = :event AND t.activeStatus = 'ACTIVE'")
     List<Team> findAllByUser(@Param("user") User user, @Param("event") Event event);
+
+
+    @Query("SELECT u FROM User u " +
+            "WHERE u.createdAt <= :threshold " +
+            "AND u.id NOT IN (" +
+            "   SELECT ut.user.id FROM UserTeam ut " +
+            "   WHERE ut.team.teamType = 'TWO_TO_TWO'" +
+            ")")
+    List<User> findUsersNotInTwoToTwoTeam(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -31,4 +31,10 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     @Query("SELECT ut FROM UserTeam ut WHERE ut.user = :user AND ut.team.activeStatus = 'ACTIVE'")
     List<UserTeam> findByUser(@Param("user") User user);
+
+    @Query("SELECT ut.user.id FROM UserTeam ut WHERE ut.team.id = :teamId")
+    List<Long> findUserIdsByTeamId(@Param("teamId") Long teamId);
+
+    @Query("SELECT ut.user.id FROM UserTeam ut WHERE ut.team.id IN :teamIds")
+    List<Long> findUserIdsByTeamIds(@Param("teamIds") List<Long> teamIds);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandService.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiCommandService.java
@@ -3,8 +3,8 @@ package com.gdg.z_meet.domain.meeting.service;
 import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
 
 public interface HiCommandService {
-    void sendHi(MeetingRequestDTO.hiDto hiDto);
-    void sendUserHi(MeetingRequestDTO.hiDto hiDto);
-    void sendTeamHi(MeetingRequestDTO.hiDto hiDto);
-    void refuseHi(MeetingRequestDTO.hiDto hiDto);
+    void sendHi(MeetingRequestDTO.HiDto hiDto);
+    void sendUserHi(MeetingRequestDTO.HiDto hiDto);
+    void sendTeamHi(MeetingRequestDTO.HiDto hiDto);
+    void refuseHi(MeetingRequestDTO.HiDto hiDto);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
@@ -1,7 +1,5 @@
 package com.gdg.z_meet.domain.meeting.service;
 
-import com.gdg.z_meet.domain.chat.dto.ChatRoomDto;
-import com.gdg.z_meet.domain.meeting.dto.MeetingRequestDTO;
 import com.gdg.z_meet.domain.meeting.dto.MeetingResponseDTO;
 import com.gdg.z_meet.domain.meeting.entity.Hi;
 import com.gdg.z_meet.domain.meeting.entity.Team;
@@ -113,7 +111,7 @@ public class HiQueryServiceImpl implements HiQueryService{
                 long totalMinutesRemaining = (5 * 60) - totalMinutesElapsed; // 5시간(300분) 기준으로 남은 분 계산
 
                 if (totalMinutesRemaining <= 0) {
-                    hi.changeStatus(HiStatus.EXPIRED);
+                    hi.setChangeStatus(HiStatus.EXPIRED);
                     hiRepository.save(hi);
                     continue;
                 }
@@ -124,7 +122,7 @@ public class HiQueryServiceImpl implements HiQueryService{
                 dateTime = String.format("%d시간 %d분 남음", remainingHours, remainingMinutes);
 
                 if(remainingHours<=0 || remainingMinutes<0){
-                    hi.changeStatus(HiStatus.EXPIRED);
+                    hi.setChangeStatus(HiStatus.EXPIRED);
                     hiRepository.save(hi);
                     continue;
                 }

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
@@ -45,7 +45,8 @@ public class User extends BaseEntity implements UserDetails {
     private boolean pushAgree;
 
     @Column(nullable = false)
-    private boolean fcmSentTwoTwo = false;
+    @Builder.Default
+    private boolean fcmSendTwoTwo = false;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -92,6 +93,6 @@ public class User extends BaseEntity implements UserDetails {
 
     public void setPushAgree(boolean pushAgree) { this.pushAgree = pushAgree;}
 
-    public void setFcmSentTwoTwo(boolean fcmSentTwoTwo) {this.fcmSentTwoTwo = fcmSentTwoTwo;}
+    public void setFcmSendTwoTwo(boolean fcmSendTwoTwo) {this.fcmSendTwoTwo = fcmSendTwoTwo;}
 
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
@@ -44,17 +44,8 @@ public class User extends BaseEntity implements UserDetails {
     @ColumnDefault("false")
     private boolean pushAgree;
 
-    public void setPushAgree(boolean pushAgree) {
-        this.pushAgree = pushAgree;
-    }
-
-    public void setIsDeleted(boolean isDeleted) {
-        this.isDeleted = isDeleted;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
+    @Column(nullable = false)
+    private boolean fcmSentTwoTwo = false;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -90,4 +81,17 @@ public class User extends BaseEntity implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    public void setIsDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setPushAgree(boolean pushAgree) { this.pushAgree = pushAgree;}
+
+    public void setFcmSentTwoTwo(boolean fcmSentTwoTwo) {this.fcmSentTwoTwo = fcmSentTwoTwo;}
+
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -86,7 +86,8 @@ public class UserProfile {
     private Verification verification = Verification.NONE;
 
     @Column(nullable = false)
-    private boolean fcmSentOneOne = false;
+    @Builder.Default
+    private boolean fcmSendOneOne = false;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -110,5 +111,5 @@ public class UserProfile {
 
     public void setInfiniteTicket() { this.ticket = 99; }
 
-    public void setFcmSentOneOne(boolean fcmSentOneOne) { this.fcmSentOneOne = fcmSentOneOne; }
+    public void setFcmSendOneOne(boolean fcmSendOneOne) { this.fcmSendOneOne = fcmSendOneOne; }
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -85,6 +85,9 @@ public class UserProfile {
     @Builder.Default
     private Verification verification = Verification.NONE;
 
+    @Column(nullable = false)
+    private boolean fcmSentOneOne = false;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -106,4 +109,6 @@ public class UserProfile {
     public void upLevel() { this.level = Level.PLUS; }
 
     public void setInfiniteTicket() { this.ticket = 99; }
+
+    public void setFcmSentOneOne(boolean fcmSentOneOne) { this.fcmSentOneOne = fcmSentOneOne; }
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,4 +32,7 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
     boolean existsByNickname(String nickname);
 
     void deleteByUserId(Long userId);
+
+    @Query("SELECT up FROM UserProfile up WHERE up.profileStatus = 'NONE' AND up.fcmSent = false AND up.user.createdAt <= :threshold")
+    List<UserProfile> findInactiveUsers(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
@@ -33,6 +33,6 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
 
     void deleteByUserId(Long userId);
 
-    @Query("SELECT up FROM UserProfile up WHERE up.profileStatus = 'NONE' AND up.fcmSent = false AND up.user.createdAt <= :threshold")
+    @Query("SELECT up FROM UserProfile up WHERE up.profileStatus = 'NONE' AND up.fcmSendOneOne = false AND up.user.createdAt <= :threshold")
     List<UserProfile> findInactiveUsers(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/gdg/z_meet/global/config/QueryDslConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.gdg.z_meet.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/gdg/z_meet/service/FcmServiceImplTest.java
+++ b/src/test/java/com/gdg/z_meet/service/FcmServiceImplTest.java
@@ -2,7 +2,7 @@ package com.gdg.z_meet.service;
 
 import com.gdg.z_meet.domain.fcm.entity.FcmToken;
 import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
-import com.gdg.z_meet.domain.fcm.service.FcmServiceImpl;
+import com.gdg.z_meet.domain.fcm.service.FcmMessageClient;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.repository.UserRepository;
 import com.gdg.z_meet.global.exception.BusinessException;
@@ -35,7 +35,7 @@ class FcmServiceImplTest {
     private FcmTokenRepository fcmTokenRepository;
 
     @InjectMocks
-    private FcmServiceImpl fcmService;
+    private FcmMessageClient fcmMessageClient;
 
     @Mock
     private FirebaseMessaging firebaseMessaging;
@@ -60,7 +60,7 @@ class FcmServiceImplTest {
             when(firebaseMessaging.send(any(Message.class))).thenReturn("알림 전송에 성공하셨습니다 !!!");
 
             // when
-            fcmService.sendFcmMessage(userId, title, body);
+            fcmMessageClient.sendFcmMessage(userId, title, body);
 
             // then
             verify(firebaseMessaging, times(1)).send(any(Message.class));  // 한 번만 호출되었는지 확인
@@ -87,7 +87,7 @@ class FcmServiceImplTest {
             when(firebaseMessaging.send(any(Message.class))).thenThrow(new BusinessException(Code.FCM_SEND_MESSAGE_ERROR));
 
             // when
-            fcmService.sendFcmMessage(userId, title, body);
+            fcmMessageClient.sendFcmMessage(userId, title, body);
 
             // then
             verify(fcmTokenRepository).delete(deviceToken);  // 무효 토큰 삭제 확인


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #177 

## ⚡️ 작업동기

- 

## 🔑 주요 변경사항

- `미팅`
  1. 가입은 했는데, 1일이 지나도 1대1 참여안했을 때 알림
  2. 가입은 했는데, 1일이 지나도 2대2 팀 안 만들었을 때 알림

- `1대1`
  1. 하이받았을 때 알림
  2. 하이 수락시간이 1시간 남았을 때 알림
 
- `2대2`
  1. 하이받았을 때 알림
  2. 하이 수락시간이 1시간 남았을 때 알림
 
API 호출과 연관된 알림들은 호출 시 전송되고, 관련 없이 발송되어야 하는 알림들은 `스케쥴링`을 통해 `백그라운드`에서도 알림이 전송되도록 하였습니다.

1대1 과 2대2의 경우 남은 시간에 대한 정밀한 제어와 다수의 동적인 조건 체킹이 필요했기에 JPQL/Native Query 가 아닌 `QueryDSL` 를 도입하여 구현하였습니다.

  


## 💡 관련 이슈

- 

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!