### PR TITLE
[FEAT] FCM 1:1 & 2:2 프로필 조회 수 관련 알림 구현

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmMeetingMessageService.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmMeetingMessageService.java
@@ -105,7 +105,7 @@ public class FcmMeetingMessageService {
                 hiQueryService.checkHiList(userId, "Receive");
                 fcmMessageClient.sendFcmMessage(userId, title, body);
             } catch (Exception e) {
-                log.error(" FCM 받은 하이 여부 메시지 전송 실패 userId: {}, message: {}", userId, e.getMessage(), e);
+                log.error("FCM 받은 하이 여부 메시지 전송 실패 userId: {}, message: {}", userId, e.getMessage(), e);
             }
         }
     }

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmProfileMessageService.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmProfileMessageService.java
@@ -1,0 +1,58 @@
+package com.gdg.z_meet.domain.fcm.service.custom;
+
+import com.gdg.z_meet.domain.fcm.service.FcmMessageClient;
+import com.gdg.z_meet.domain.user.entity.UserProfile;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmProfileMessageService {
+
+    private final FcmMessageClient fcmMessageClient;
+
+    // 프로필 조회 API 호출 시 실행되어야
+    @Transactional
+    public void messagingProfileViewOneOneUsers(List<UserProfile> profiles) {
+        Map<Integer, String> messageTitles = Map.of(
+                10, "🥳 내 프로필을 10명이나 봤어요! 🎉 오늘도 인기 폭발 시작이에요!",
+                50, "🔥 벌써 50명이 다녀갔어요! 대세는 역시 나, 지금 확인해보세요!",
+                100, "💯 무려 100명이 당신을 봤어요! 관심 폭주 중이에요, 놓치지 마세요!",
+                500, "🌟 500명 돌파! 이 정도면 거의 스타 등장이죠? 지금 확인해봐요!",
+                1000, "🏆 1000명 초과 달성! ZI밋에서 당신의 인기가 뜨겁게 타오르고 있어요!"
+        );
+        String body = "인기있는 당신! 어떤 사람들이 ZI밋에 있는지 확인해볼까요?🔥";
+
+        for (UserProfile profile : profiles) {
+            int viewCount = profile.getViewCount();
+            Long userId = profile.getUser().getId();
+
+            if (messageTitles.containsKey(viewCount)) {
+                String title = messageTitles.get(viewCount);
+                try {
+                    fcmMessageClient.sendFcmMessage(userId, title, body);
+                } catch (Exception e) {
+                    log.error("FCM 프로필 조회 수 알림 전송 실패 - userId: {}, message: {}", userId, e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+
+    @Transactional
+    @Scheduled(fixedRate = 60000)      // 1분마다 실행
+    public void messagingProfileViewTwoTwoUsers() {
+
+
+        String title = "👀 아직 내 프로필이 활성화되지 않았어요.";
+        String body = "연애 지수 폭발 중!🔥어떤 팀들이 기다리고 있는지 ZI밋에서 확인해보세요!";
+
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmProfileMessageService.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/custom/FcmProfileMessageService.java
@@ -1,10 +1,13 @@
 package com.gdg.z_meet.domain.fcm.service.custom;
 
 import com.gdg.z_meet.domain.fcm.service.FcmMessageClient;
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.UserTeam;
+import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
+import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.entity.UserProfile;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,18 +20,19 @@ import java.util.Map;
 public class FcmProfileMessageService {
 
     private final FcmMessageClient fcmMessageClient;
+    private final UserTeamRepository userTeamRepository;
 
     // 프로필 조회 API 호출 시 실행되어야
     @Transactional
     public void messagingProfileViewOneOneUsers(List<UserProfile> profiles) {
         Map<Integer, String> messageTitles = Map.of(
-                10, "🥳 내 프로필을 10명이나 봤어요! 🎉 오늘도 인기 폭발 시작이에요!",
+                10, "🥳 내 프로필을 10명이나 봤어요! 🎉 인기 폭발 시작이에요!",
                 50, "🔥 벌써 50명이 다녀갔어요! 대세는 역시 나, 지금 확인해보세요!",
                 100, "💯 무려 100명이 당신을 봤어요! 관심 폭주 중이에요, 놓치지 마세요!",
                 500, "🌟 500명 돌파! 이 정도면 거의 스타 등장이죠? 지금 확인해봐요!",
                 1000, "🏆 1000명 초과 달성! ZI밋에서 당신의 인기가 뜨겁게 타오르고 있어요!"
         );
-        String body = "인기있는 당신! 어떤 사람들이 ZI밋에 있는지 확인해볼까요?🔥";
+        String body = "인기있는 당신!! 어떤 사람들이 ZI밋에 있는지 확인해볼까요?🔥";
 
         for (UserProfile profile : profiles) {
             int viewCount = profile.getViewCount();
@@ -47,12 +51,33 @@ public class FcmProfileMessageService {
 
 
     @Transactional
-    @Scheduled(fixedRate = 60000)      // 1분마다 실행
-    public void messagingProfileViewTwoTwoUsers() {
+    public void messagingProfileViewTwoTwoUsers(List<Team> teams) {
+        Map<Integer, String> messageTitles = Map.of(
+                10, "🥳 우리 팀 프로필을 10명이나 봤어요! 🎉 인기 폭발 시작이에요!",
+                50, "🔥 벌써 50명이 다녀갔어요! 대세는 역시 우리 팀, 지금 확인해보세요!",
+                100, "💯 무려 100명이 우리 팀을 봤어요! 관심 폭주 중이에요, 놓치지 마세요!",
+                500, "🌟 500명 돌파! 이 정도면 거의 스타 등장이죠? 지금 확인해봐요!",
+                1000, "🏆 1000명 초과 달성! ZI밋에서 우리 팀의 인기가 뜨겁게 타오르고 있어요!"
+        );
+        String body = "인기있는 우리 팀!! 어떤 팀들이 ZI밋에 있는지 확인해볼까요?🔥";
 
 
-        String title = "👀 아직 내 프로필이 활성화되지 않았어요.";
-        String body = "연애 지수 폭발 중!🔥어떤 팀들이 기다리고 있는지 ZI밋에서 확인해보세요!";
+        for (Team team : teams) {
+            int viewCount = team.getViewCount();
 
+            if (messageTitles.containsKey(viewCount)) {
+                String title = messageTitles.get(viewCount);
+
+                List<UserTeam> userTeams = userTeamRepository.findAllByTeam(team);
+                for (UserTeam userTeam : userTeams) {
+                    Long userId = userTeam.getUser().getId();
+                    try {
+                        fcmMessageClient.sendFcmMessage(userId, title, body);
+                    } catch (Exception e) {
+                        log.error("FCM 팀 조회 수 알림 전송 실패 - userId: {}, teamId: {}, message: {}", userId, team.getId(), e.getMessage(), e);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
@@ -58,6 +58,10 @@ public class Team extends BaseEntity {
     @Builder.Default
     private int viewCount = 0;
 
+    @Column(name = "last_notified")
+    @Builder.Default
+    private Integer lastNotified = 0;
+
     // hi 값을 변경하는 메서드
     public void decreaseHi() {
         if (this.hi > 0) {
@@ -82,4 +86,6 @@ public class Team extends BaseEntity {
     public int getViewCount() { return viewCount; }
 
     public void setViewCount(int viewCount) { this.viewCount = viewCount; }
+
+    public void setLastNotified(Integer lastNotified) { this.lastNotified = lastNotified; }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/entity/Team.java
@@ -54,6 +54,10 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Event event;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int viewCount = 0;
+
     // hi 값을 변경하는 메서드
     public void decreaseHi() {
         if (this.hi > 0) {
@@ -74,4 +78,8 @@ public class Team extends BaseEntity {
     public void setInfiniteHi() { this.hi = 99; }
 
     public void patchVerification() { this.verification = Verification.COMPLETE; }
+
+    public int getViewCount() { return viewCount; }
+
+    public void setViewCount(int viewCount) { this.viewCount = viewCount; }
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/UserTeamRepository.java
@@ -1,5 +1,6 @@
 package com.gdg.z_meet.domain.meeting.repository;
 
+import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.UserTeam;
 import com.gdg.z_meet.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -37,4 +38,7 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
 
     @Query("SELECT ut.user.id FROM UserTeam ut WHERE ut.team.id IN :teamIds")
     List<Long> findUserIdsByTeamIds(@Param("teamIds") List<Long> teamIds);
+
+    @Query("SELECT ut FROM UserTeam ut JOIN FETCH ut.user WHERE ut.team = :team")
+    List<UserTeam> findAllByTeam(@Param("team") Team team);
 }

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -77,7 +77,6 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
             team.setViewCount(team.getViewCount() + 1);
         }
 
-        teamRepository.saveAll(teamList);
         fcmProfileMessageService.messagingProfileViewTwoTwoUsers(teamList);
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -61,12 +61,24 @@ public class MeetingQueryServiceImpl implements MeetingQueryService {
         List<Team> teamList = teamRepository.findAllByTeamType(userId, gender, teamType, event, PageRequest.of(page, 12));
         Collections.shuffle(teamList);
 
+        self.increaseTeamViewCountsAndSendFcm(teamList);
+
         Map<Long, List<String>> emojiList = collectEmoji(teamList);
         Map<Long, List<String>> majorList = collectMajor(teamList);
         Map<Long, Double> age = collectAge(teamList);
         Map<Long, List<String>> musicList = collectMusic(teamList);
 
         return MeetingConverter.toGetTeamGalleryDTO(teamList, emojiList, majorList, age, musicList);
+    }
+
+    @Transactional
+    public void increaseTeamViewCountsAndSendFcm(List<Team> teamList) {
+        for (Team team : teamList) {
+            team.setViewCount(team.getViewCount() + 1);
+        }
+
+        teamRepository.saveAll(teamList);
+        fcmProfileMessageService.messagingProfileViewTwoTwoUsers(teamList);
     }
 
     @Override

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -89,6 +89,10 @@ public class UserProfile {
     @Builder.Default
     private boolean fcmSendOneOne = false;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int viewCount = 0;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -112,4 +116,8 @@ public class UserProfile {
     public void setInfiniteTicket() { this.ticket = 99; }
 
     public void setFcmSendOneOne(boolean fcmSendOneOne) { this.fcmSendOneOne = fcmSendOneOne; }
+
+    public int getViewCount() { return viewCount; }
+
+    public void setViewCount(int viewCount) { this.viewCount = viewCount; }
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/UserProfile.java
@@ -93,6 +93,10 @@ public class UserProfile {
     @Builder.Default
     private int viewCount = 0;
 
+    @Column(name = "last_notified")
+    @Builder.Default
+    private Integer lastNotified = 0;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserProfileRepository.java
@@ -35,4 +35,6 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
 
     @Query("SELECT up FROM UserProfile up WHERE up.profileStatus = 'NONE' AND up.fcmSendOneOne = false AND up.user.createdAt <= :threshold")
     List<UserProfile> findInactiveUsers(@Param("threshold") LocalDateTime threshold);
+
+    List<UserProfile> findByUserIdIn(List<Long> userIds);
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #197 

## ⚡️ 작업동기

- 

## 🔑 주요 변경사항

- 1:1 과 2:2 상황에서 갤러리 조회 시 뜨는 프로필에 대한 조회 수 알림을 구현하였습니다. 

## 💡 관련 이슈

- 

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!