### PR TITLE
[FIX] 1대1 미팅 랜덤 정렬

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -49,10 +49,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findByIdIn(List<Long> userIds);
 
-    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up " +
-            "WHERE u.id != :userId AND up.gender != :gender AND up.profileStatus = 'ACTIVE' AND u.isDeleted = false " +
-            "ORDER BY FUNCTION('RAND')")
-    List<User> findAllByProfileStatus(@Param("userId") Long userId, @Param("gender") Gender gender, Pageable pageable);
+    @Query("SELECT u.id FROM User u JOIN u.userProfile up " +
+            "WHERE u.id != :userId AND up.gender != :gender AND up.profileStatus = 'ACTIVE' AND u.isDeleted = false")
+    List<Long> findAllByProfileStatus(@Param("userId") Long userId, @Param("gender") Gender gender);
+
+    @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.id IN :ids")
+    List<User> findByIdInWithProfile(@Param("ids") List<Long> ids);
 
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile up " +
             "WHERE u.id = :userId AND up.profileStatus = 'ACTIVE' AND u.isDeleted = false")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,3 +62,6 @@ kakao:
     cid: TC0ONETIME
     ready-url: https://open-api.kakaopay.com/online/v1/payment/ready
     approve-url: https://open-api.kakaopay.com/online/v1/payment/approve
+
+firebase:
+  admin-sdk: firebase/zi-meet-firebase-adminsdk-fbsvc-f026a2abf0.json


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feat/#191_random-order

## ⚡️ 작업동기

- 1대1 미팅 갤러리 랜덤 정렬 기능 수정

## 🔑 주요 변경사항

- 페이지마다 중복되는 유저 없도록 조회
- 로컬 메모리로 10분마다 랜덤 유저 리스트 생성하여 페이징
- 유저마다 일괄로 초기화할 필요가 없기 때문에 @ Scheduled 대신 요청 시마다 시간 체크하는 timestamp 사용

## 💡 관련 이슈

- #191 

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<img width="1608" alt="스크린샷 2025-05-15 오후 9 46 06" src="https://github.com/user-attachments/assets/9af3d7ee-43c5-46f5-9981-3b2caa62b1df" />

<img width="1608" alt="스크린샷 2025-05-15 오후 9 46 44" src="https://github.com/user-attachments/assets/26a9ada2-94f1-43b7-8523-8a35409dbe84" />
