### PR TITLE
[FIX] 역직렬화 오류로 인한 ObjectMapper 설정 수정

### DIFF
--- a/src/main/java/com/gdg/z_meet/global/config/RedisConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/RedisConfig.java
@@ -95,11 +95,11 @@ public class RedisConfig {
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-        objectMapper.activateDefaultTyping(
-                objectMapper.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.NON_FINAL,
-                JsonTypeInfo.As.PROPERTY
-        );
+//        objectMapper.activateDefaultTyping(
+//                objectMapper.getPolymorphicTypeValidator(),
+//                ObjectMapper.DefaultTyping.NON_FINAL,
+//                JsonTypeInfo.As.PROPERTY
+//        );
 
         return objectMapper;
     }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #230 

## ⚡️ 작업동기

[문제가 되었던 설정들] 
- `DefaultTyping.NON_FINAL` :  DTO와 같은 모든 final이 아닌 타입에 대해 다형성 처리를 활성화
- `As.PROPERTY` : 타입 정보를 JSON 내부의 @class 속성으로 명시하라고 요구

즉, 해당 설정으로 모든 non-final 객체를 역직렬화 시, JSON에 "@class": "com.xxx.YourType" 같은 정보가 있어야 동작했었음
따라서 해당 설정 제거 


## 🔑 주요 변경사항

- 

## 💡 관련 이슈

- 

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!