### PR TITLE
[FIX] 하이 리스트에서 다른 유저 데이터 조회

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
@@ -26,7 +26,7 @@ public interface HiRepository extends JpaRepository<Hi,Long>, HiRepositoryCustom
             "AND h.hiStatus != 'DELETED' ORDER BY h.createdAt DESC")
     List<Hi> findSendHiList(@Param("teamIds") List<Long> teamIds, @Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Hi h SET h.hiStatus = 'DELETED' WHERE h.fromId = :teamId OR h.toId = :teamId")
     void updateHiByTeamId(@Param("teamId") Long teamId);
 

--- a/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/repository/HiRepository.java
@@ -1,7 +1,6 @@
 package com.gdg.z_meet.domain.meeting.repository;
 
 import com.gdg.z_meet.domain.meeting.entity.Hi;
-import com.gdg.z_meet.domain.meeting.entity.Team;
 import com.gdg.z_meet.domain.meeting.entity.enums.HiStatus;
 import com.gdg.z_meet.domain.meeting.entity.enums.HiType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,10 +15,17 @@ import java.util.Optional;
 public interface HiRepository extends JpaRepository<Hi,Long>, HiRepositoryCustom {
     Boolean existsByFromIdAndToIdAndHiStatusNotAndHiType(Long from, Long to, HiStatus status, HiType hiType);
     Hi findByFromIdAndToIdAndHiStatus(Long from, Long to, HiStatus status);
-    @Query("SELECT DISTINCT h FROM Hi h WHERE h.toId IN (:teamIds) AND h.hiStatus='NONE' ORDER BY h.createdAt DESC")
-    List<Hi> findRecevieHiList(@Param("teamIds") List<Long> teamIds);
-    @Query("SELECT DISTINCT h FROM Hi h WHERE h.fromId IN (:teamIds) AND h.hiStatus!='DELETED' ORDER BY h.createdAt DESC")
-    List<Hi> findSendHiList(@Param("teamIds") List<Long> teamIds);
+
+    @Query("SELECT DISTINCT h FROM Hi h WHERE " +
+            "( (h.hiType = 'TEAM' AND h.toId IN (:teamIds)) OR (h.hiType = 'USER' AND h.toId = :userId) ) " +
+            "AND h.hiStatus = 'NONE' ORDER BY h.createdAt DESC")
+    List<Hi> findRecevieHiList(@Param("teamIds") List<Long> teamIds, @Param("userId") Long userId);
+
+    @Query("SELECT DISTINCT h FROM Hi h WHERE " +
+            "( (h.hiType = 'TEAM' AND h.fromId IN (:teamIds)) OR (h.hiType = 'USER' AND h.fromId = :userId) ) " +
+            "AND h.hiStatus != 'DELETED' ORDER BY h.createdAt DESC")
+    List<Hi> findSendHiList(@Param("teamIds") List<Long> teamIds, @Param("userId") Long userId);
+
     @Modifying
     @Query("UPDATE Hi h SET h.hiStatus = 'DELETED' WHERE h.fromId = :teamId OR h.toId = :teamId")
     void updateHiByTeamId(@Param("teamId") Long teamId);

--- a/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/meeting/service/HiQueryServiceImpl.java
@@ -44,15 +44,12 @@ public class HiQueryServiceImpl implements HiQueryService{
                 .map(userTeam -> userTeam.getTeam().getId()) // UserTeam에서 teamId 추출
                 .collect(Collectors.toList());
 
-        //myTeamIds에 userId추가
-        myTeamIds.add(userId);
-
         List<Hi> hiList;
         if(action.equals("Receive")) {
-            hiList = hiRepository.findRecevieHiList(myTeamIds);
+            hiList = hiRepository.findRecevieHiList(myTeamIds, userId);
         }
         else{
-            hiList = hiRepository.findSendHiList(myTeamIds);
+            hiList = hiRepository.findSendHiList(myTeamIds, userId);
         }
 
         // 여러 개의 hiListDto 생성


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix/#250_hi

## ⚡️ 작업동기

- 받은 하이, 보낸 하이 조회 시 다른 유저 데이터도 같이 조회되는 에러 해결

## 🔑 주요 변경사항

- 하이 타입에 따라서 조회하는 인덱스 변경
- 수정 전: 팀 아이디 리스트에 유저 아이디 추가 후, 하이 타입 구분없이 리스트에 해당하는 모든 하이 조회
-> 유저 아이디가 1일 경우, 인덱스가 1에 해당하는 1대1, 2대2 하이를 모두 조회하는 문제 발생
- 수정 후: 하이 타입에 따라 각각 팀 아이디와 유저 아이디로 구분하여 조회

## 💡 관련 이슈

- #250 

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

수정 전
<img width="1608" alt="수정 전" src="https://github.com/user-attachments/assets/cf2b1b8e-b7ae-46eb-a333-ca90a40faee1" />

수정 후
<img width="1608" alt="수정 후" src="https://github.com/user-attachments/assets/f084e565-85e6-4879-bf81-bd5cf423ac75" />